### PR TITLE
Fix instruction hook C linkage and callback shape for Emscripten\n\n-…

### DIFF
--- a/m68kconf.h
+++ b/m68kconf.h
@@ -162,8 +162,14 @@
  * instruction.
  */
 #define M68K_INSTRUCTION_HOOK       OPT_SPECIFY_HANDLER
-int m68k_instruction_hook_wrapper(unsigned int pc, unsigned int ir, unsigned int cycles);
-#define M68K_INSTRUCTION_CALLBACK(pc, ir, cycles) m68k_instruction_hook_wrapper(pc, ir, cycles)
+#ifdef __cplusplus
+extern "C" {
+#endif
+int my_instruction_hook_function(unsigned int pc);
+#ifdef __cplusplus
+}
+#endif
+#define M68K_INSTRUCTION_CALLBACK(pc, ir, cycles) my_instruction_hook_function(pc)
 
 
 /* If ON, the CPU will emulate the 4-byte prefetch queue of a real 68000 */

--- a/myfunc.cc
+++ b/myfunc.cc
@@ -184,7 +184,7 @@ unsigned int m68k_read_disassembler_32(unsigned int address) {
   return m68k_read_memory_32(address);
 }
 
-int my_instruction_hook_function(unsigned int pc) {
+extern "C" int my_instruction_hook_function(unsigned int pc) {
   // Only call the hook if it's set and we want to break on this address
   if (_pc_hook) {
     // Optionally check if we have specific addresses to hook


### PR DESCRIPTION
… Declare instruction hook in m68kconf.h with extern "C"\n- Route M68K_INSTRUCTION_CALLBACK to a pc-only C shim\n- Define my_instruction_hook_function with extern "C" in myfunc.cc\n\nThis avoids wasm dynCall signature mismatches and removes the need for fpcast thunks.