### PR TITLE
Release version 0.1.3 - Browser compatibility fix and documentation improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-08-17
+
+### 🐛 Bug Fixes
+
+- **Browser compatibility fix**: Fixed critical browser compatibility issue where `fileURLToPath` was imported at the top level, breaking Vite/webpack builds
+  - The fix uses conditional dynamic imports - Node.js modules are only loaded in Node.js environments
+  - Browser environments now use `URL.href` directly without importing Node.js-specific modules
+  - This resolves build errors in modern bundlers like Vite and webpack
+
+### 📚 Documentation
+
+- **Hook function clarification**: Clarified hook function usage in documentation
+  - `_set_pc_hook_func` takes only PC parameter (signature 'ii'): `int hook(unsigned int pc)`
+  - `_set_full_instr_hook_func` provides PC, instruction register, and cycles (signature 'iiii'): `int hook(unsigned int pc, unsigned int ir, unsigned int cycles)`
+  - Added clear guidance on when to use each hook type for different use cases
+
 ## [0.1.1] - 2025-08-16
 
 ### 🚨 Breaking Changes

--- a/README.md
+++ b/README.md
@@ -109,6 +109,43 @@ if (system.tracer.isAvailable()) {
 
 View traces at [ui.perfetto.dev](https://ui.perfetto.dev).
 
+## Hook Functions
+
+The emulator provides two types of hook functions for monitoring and debugging:
+
+### PC Hooks
+For simple breakpoint-style debugging and JavaScript/WASM integration:
+
+```javascript
+// Set PC hook function - signature: int hook(unsigned int pc)
+Module._set_pc_hook_func(Module.addFunction(myHook, 'ii'));
+
+// Hook specific addresses only (optional filtering)
+Module._add_pc_hook_addr(0x1000);  // Hook only address 0x1000
+Module._add_pc_hook_addr(0x2000);  // Also hook address 0x2000
+
+// Clear PC hook
+Module._clear_pc_hook_func();
+Module._clear_pc_hook_addrs();     // Clear address filter (hook all)
+```
+
+### Full Instruction Hooks
+For detailed instruction analysis with opcode and cycle information:
+
+```javascript
+// Set full instruction hook - signature: int hook(unsigned int pc, unsigned int ir, unsigned int cycles)
+Module._set_full_instr_hook_func(Module.addFunction(detailedHook, 'iiii'));
+
+// Clear instruction hook
+Module._clear_instr_hook_func();
+```
+
+**When to use which:**
+- Use **PC Hooks** for breakpoints, simple debugging, and JavaScript integration
+- Use **Full Instruction Hooks** for performance analysis, detailed instruction tracing, and when you need opcode/cycle data
+
+Both hook functions should return 0 to continue execution, or non-zero to break out of the execution loop.
+
 ## Project Structure
 
 ```

--- a/npm-package/index.mjs
+++ b/npm-package/index.mjs
@@ -1,0 +1,23 @@
+import createModule from "./dist/musashi-loader.mjs";
+
+export default function init(options = {}) {
+  const isNode = typeof process !== "undefined" && !!process.versions?.node;
+  const wasmUrl = new URL("./dist/musashi.wasm", import.meta.url);
+  
+  // Browser-compatible path handling
+  let wasmPath;
+  if (isNode) {
+    // Only import fileURLToPath in Node.js environments
+    // Using dynamic import to avoid top-level import that breaks browsers
+    return import("url").then(({ fileURLToPath }) => {
+      wasmPath = fileURLToPath(wasmUrl);
+      const locateFile = (p) => p.endsWith(".wasm") ? wasmPath : p;
+      return createModule({ locateFile, ...options });
+    });
+  } else {
+    // Browser environment - use URL directly
+    wasmPath = wasmUrl.href;
+    const locateFile = (p) => p.endsWith(".wasm") ? wasmPath : p;
+    return createModule({ locateFile, ...options });
+  }
+}

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,24 +1,26 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "index.mjs",
+    "perf.mjs"
   ],
   "exports": {
     ".": {
-      "import": "./lib/index.mjs",
+      "import": "./index.mjs",
       "types": "./lib/index.d.ts"
     },
     "./perfetto": {
-      "import": "./lib/perfetto.mjs",
+      "import": "./perf.mjs",
       "types": "./lib/perfetto.d.ts"
     }
   },
   "types": "./lib/index.d.ts",
-  "main": "./lib/index.mjs",
+  "main": "./index.mjs",
   "keywords": [
     "m68k",
     "m68000",

--- a/npm-package/perf.mjs
+++ b/npm-package/perf.mjs
@@ -1,0 +1,23 @@
+import createModule from "./dist/musashi-perfetto-loader.mjs";
+
+export default function init(options = {}) {
+  const isNode = typeof process !== "undefined" && !!process.versions?.node;
+  const wasmUrl = new URL("./dist/musashi-perfetto.wasm", import.meta.url);
+  
+  // Browser-compatible path handling
+  let wasmPath;
+  if (isNode) {
+    // Only import fileURLToPath in Node.js environments
+    // Using dynamic import to avoid top-level import that breaks browsers
+    return import("url").then(({ fileURLToPath }) => {
+      wasmPath = fileURLToPath(wasmUrl);
+      const locateFile = (p) => p.endsWith(".wasm") ? wasmPath : p;
+      return createModule({ locateFile, ...options });
+    });
+  } else {
+    // Browser environment - use URL directly
+    wasmPath = wasmUrl.href;
+    const locateFile = (p) => p.endsWith(".wasm") ? wasmPath : p;
+    return createModule({ locateFile, ...options });
+  }
+}


### PR DESCRIPTION
## Summary

This PR releases version 0.1.3 of musashi-wasm with critical bug fixes for browser compatibility and improved documentation.

### Key Changes

🐛 **Browser Compatibility Fix (Critical)**
- Fixed browser compatibility issue where `fileURLToPath` was imported at the top level, breaking Vite/webpack builds
- Implemented conditional dynamic imports - Node.js modules are only loaded in Node.js environments  
- Browser environments now use `URL.href` directly without importing Node.js-specific modules
- This resolves build errors in modern bundlers like Vite and webpack

📚 **Hook Function Documentation**
- Added comprehensive hook function documentation to README with clear usage examples
- Clarified the difference between PC hooks and full instruction hooks:
  - `_set_pc_hook_func` takes only PC parameter (signature 'ii'): `int hook(unsigned int pc)`
  - `_set_full_instr_hook_func` provides PC, instruction register, and cycles (signature 'iiii'): `int hook(unsigned int pc, unsigned int ir, unsigned int cycles)`
- Added guidance on when to use each hook type for different use cases

### Files Changed

- `npm-package/package.json` - Version bump to 0.1.3
- `npm-package/index.mjs` - Browser compatibility fix with conditional imports
- `npm-package/perf.mjs` - Browser compatibility fix with conditional imports  
- `README.md` - Added comprehensive hook function documentation
- `CHANGELOG.md` - Detailed v0.1.3 release notes

### Testing

The browser compatibility fix has been tested and resolves the import issues that were breaking builds in Vite and webpack environments. The hook function documentation provides clear examples for both PC hooks and full instruction hooks.

### Release Type

This is a **patch release** (0.1.2 → 0.1.3) that fixes critical browser compatibility issues and improves documentation. No breaking changes.

🤖 Generated with [Claude Code](https://claude.ai/code)