### PR TITLE
Release v0.1.4

### DIFF
--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 for npm release
- Includes recent fixes:
  - Browser export support (`index-browser.mjs`)
  - Big-endian memory read fixes for 16/32-bit operations
  - Hook system stability improvements

## Changes since v0.1.3
- Add minimal browser export: npm-package/index-browser.mjs re-exports index.mjs
- Minimal fix: delegate 16/32-bit reads to my_read_memory in m68k_memory_bridge.cc for correct big-endian behavior

## Release Process
After this PR is merged:
1. Tag v0.1.4 will be created
2. GitHub release will be created
3. npm package will be automatically published

🤖 Generated with [Claude Code](https://claude.ai/code)