### PR TITLE
Add minimal fusion hooks (runSync + onInstruction/onRead8/onWrite8) and Node fallback

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,17 @@ class SystemImpl implements System {
     this._musashi.init(this, config.rom, this._ram);
   }
 
+  // --- Instrumentation helpers expected by fusion harness ---
+  onInstruction(cb: ((pc: number) => void) | undefined): void {
+    this._musashi.onInstruction = cb;
+  }
+  onRead8(cb: ((addr: number, value: number) => void) | undefined): void {
+    this._musashi.onRead8 = cb;
+  }
+  onWrite8(cb: ((addr: number, value: number) => void) | undefined): void {
+    this._musashi.onWrite8 = cb;
+  }
+
   read(address: number, size: 1 | 2 | 4): number {
     return this._musashi.read_memory(address, size);
   }
@@ -190,6 +201,11 @@ class SystemImpl implements System {
 
   async run(cycles: number): Promise<number> {
     return Promise.resolve(this._musashi.execute(cycles));
+  }
+
+  // Synchronous stepping used by fusion harness for small time slices
+  runSync(cycles: number): number {
+    return this._musashi.execute(cycles >>> 0) >>> 0;
   }
 
   reset(): void {

--- a/packages/core/wasm/musashi-node-wrapper.mjs
+++ b/packages/core/wasm/musashi-node-wrapper.mjs
@@ -1,6 +1,13 @@
-// ESM wrapper for the Musashi WASM module
-// This file loads the actual ESM module that should be copied here by the CI
+// ESM wrapper for the Musashi WASM module with a safe fallback.
+// Primary path: local CI drops musashi-node.out.mjs alongside this file.
+// Fallback: use repository-level musashi-node.mjs if present.
 
-import createMusashi from './musashi-node.out.mjs';
-
-export default createMusashi;
+export default async function createMusashiModule() {
+  try {
+    const mod = await import('./musashi-node.out.mjs');
+    return mod.default();
+  } catch (_e) {
+    const fallback = await import('../../../musashi-node.mjs');
+    return fallback.default();
+  }
+}


### PR DESCRIPTION
This PR introduces the minimal compatibility surface required for the fusion harness to execute and step the third‑party musashi‑wasm core:

What’s included
- Instrumentation hooks
  - onInstruction(pc): fires once per PC hook callback so fusion can observe instruction boundaries.
  - onRead8(addr, value) and onWrite8(addr, value): byte‑level bus events for fusion’s memory comparator.
- Synchronous run stepping
  - runSync(cycles): synchronous stepping used by fusion when running tiny slices.
- Node loader fallback
  - packages/core/wasm/musashi-node-wrapper.mjs now falls back to ../../../musashi-node.mjs when musashi-node.out.mjs is not present (e.g., in local dev without CI artifacts).

Why
- The fusion harness expects these methods to exist to phase‑align and step the third‑party core alongside the local core, and to capture byte‑granular I/O.

Notes
- This is intentionally minimal; it does not change memory mapping or PPC semantics.
- Larger, more precise alignment work can follow in a separate PR.

Test plan
- Verified local Node unit tests invoke the TP core and reach fusion comparisons with MUSASHI_FUSION=1.
- Confirmed the wrapper loads via the fallback path when musashi-node.out.mjs is absent.