### PR TITLE
m68k: add end-of-instruction boundary hook (post-PC)

### DIFF
--- a/myfunc.cc
+++ b/myfunc.cc
@@ -534,6 +534,17 @@ extern "C" int m68k_instruction_hook_wrapper(unsigned int pc, unsigned int ir, u
 #endif
 }
 
+// Called at end-of-instruction boundary (post-PC)
+extern "C" int m68k_instruction_end_boundary_hook(unsigned int pc) {
+  // Reuse the unified JS probe/pc_hook path
+  const int js_result = my_instruction_hook_function(pc);
+  if (js_result != 0) {
+    m68k_end_timeslice();
+    return js_result;
+  }
+  return 0;
+}
+
 /* ======================================================================== */
 /* ======================= PERFETTO TRACE API WRAPPERS =================== */
 /* ======================================================================== */


### PR DESCRIPTION
Introduce a deterministic end-of-instruction boundary callback before the next opcode fetch.\n\n- m68kcpu.c: invoke m68k_instruction_end_boundary_hook(post_pc) after each instruction and before fetching next IR.\n- myfunc.cc: implement the hook to reuse the unified JS probe/pc_hook path and end the timeslice when requested.\n\nRationale: Align hook timing with per-instruction tracing and improve determinism for tooling and embedding.\n\nNo behavior change unless a probe/hook is installed.