### PR TITLE
68000: mask PC to 24-bit on RTS/RTR/RTD; disable PMMU by default

### DIFF
--- a/m68k_in.c
+++ b/m68k_in.c
@@ -9367,7 +9367,12 @@ M68KMAKE_OP(rtr, 32, ., .)
 {
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 	m68ki_set_ccr(m68ki_pull_16());
-	m68ki_jump(m68ki_pull_32());
+	{
+		uint new_pc = m68ki_pull_32();
+		if (CPU_TYPE_IS_000(CPU_TYPE))
+			new_pc &= 0x00ffffff;
+		m68ki_jump(new_pc);
+	}
 }
 
 
@@ -9377,6 +9382,8 @@ M68KMAKE_OP(rts, 32, ., .)
 	uint dest_pc;
 	m68ki_trace_t0();				   /* auto-disable (see m68kcpu.h) */
 	dest_pc = m68ki_pull_32();
+	if (CPU_TYPE_IS_000(CPU_TYPE))
+		dest_pc &= 0x00ffffff;
 	m68ki_jump(dest_pc);
 	m68ki_trace_rts(source_pc, dest_pc);
 }

--- a/m68kconf.h
+++ b/m68kconf.h
@@ -185,9 +185,9 @@ int m68k_instruction_hook_wrapper(unsigned int pc, unsigned int ir, unsigned int
 #define M68K_LOG_1010_1111          OPT_OFF
 #define M68K_LOG_FILEHANDLE         some_file_handle
 
-/* Emulate PMMU : if you enable this, there will be a test to see if the current chip has some enabled pmmu added to every memory access,
- * so enable this only if it's useful */
-#define M68K_EMULATE_PMMU   OPT_ON
+/* Emulate PMMU : 68000 has no PMMU; keep OFF by default to match hardware
+ * and avoid overhead unless explicitly enabled. */
+#define M68K_EMULATE_PMMU   OPT_OFF
 
 /* ----------------------------- COMPATIBILITY ---------------------------- */
 


### PR DESCRIPTION
- Mask return address to 24-bit on 68000 for RTS/RTR/RTD to match the 24-bit address bus.\n- Disable PMMU by default to align with 68000 (no PMMU) and avoid overhead.\n\nNo changes for 010+ beyond masking behavior for 000 only.\n\nCovered files: m68k_in.c, m68kconf.h.