### PR TITLE
core(ts): per-instruction + byte I/O hooks; stable PPC; external I/O; disassembler helpers

### DIFF
--- a/packages/core/wasm/musashi-node-wrapper.mjs
+++ b/packages/core/wasm/musashi-node-wrapper.mjs
@@ -1,6 +1,14 @@
 // ESM wrapper for the Musashi WASM module
-// This file loads the actual ESM module that should be copied here by the CI
+// Prefer local build from repository root if present (developer-friendly),
+// otherwise fall back to a colocated build.
 
-import createMusashi from './musashi-node.out.mjs';
+let createMusashi;
+try {
+  // In this repo, CI and local builds place outputs at repo root
+  createMusashi = (await import('../../../musashi-node.out.mjs')).default;
+} catch (_e) {
+  // Fallback to colocated wrapper (if CI copied files here)
+  createMusashi = (await import('./musashi-node.out.mjs')).default;
+}
 
 export default createMusashi;


### PR DESCRIPTION
Expose new instrumentation and integration points:\n\n- System: enableSingleStep, onInstruction, onRead8, onWrite8, setExternalRead8/Write8, runSync, disassemble helpers.\n- Wrapper: implement per-instruction coalesced hooks, external 8-bit I/O interceptors, legacy 16/32 registration, stable PPC shadow, and ROM-write protection in JS path.\n- Node ESM wrapper prefers root artifact when present.\n- Remove forced reset vector writes; rely on ROM vectors for boot.\n\nKeeps default behavior unless hooks are used.