### PR TITLE
core(ts): configurable memory mapping; ROM write-protect default

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,11 @@ class SystemImpl implements System {
     this._musashi.setExternalWrite8(fn);
   }
 
+  // Configurable memory mapper (optional)
+  setMemoryMapper(mapper?: (addr: number, isWrite: boolean) => { phys: number; allowWrite: boolean }): void {
+    (this._musashi as any).setMemoryMapper?.(mapper);
+  }
+
   read(address: number, size: 1 | 2 | 4): number {
     return this._musashi.read_memory(address, size);
   }


### PR DESCRIPTION
Add an optional memory mapper to control physical address translation and write policy.\n\n- Wrapper: use mapper for 8-bit callbacks, legacy 16/32, and JS-side write_memory; default mapper retains current ROM/RAM layout and ROM write-ignore.\n- System: expose setMemoryMapper().\n\nStacked on top of wrapper instrumentation PR.