### PR TITLE
Refactor DataParser int32 handling

### DIFF
--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -226,6 +226,22 @@ describe('@m68k/memory', () => {
       expect(DataParser.readInt16BE(data, 4)).toBe(32767);
     });
 
+    test('should read 32-bit signed integers', () => {
+      const data = new Uint8Array([
+        0xff,
+        0xff,
+        0xff,
+        0xfe, // -2
+        0x7f,
+        0xff,
+        0xff,
+        0xff, // 0x7fffffff
+      ]);
+
+      expect(DataParser.readInt32BE(data, 0)).toBe(-2);
+      expect(DataParser.readInt32BE(data, 4)).toBe(0x7fffffff);
+    });
+
     test('should write unsigned integers', () => {
       const data = new Uint8Array(6);
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -98,13 +98,9 @@ export class DataParser {
 
   /** Reads a big-endian 32-bit signed integer. */
   static readInt32BE(data: Uint8Array, offset: number = 0): number {
-    return (
-      (data[offset] << 24) |
-      (data[offset + 1] << 16) |
-      (data[offset + 2] << 8) |
-      data[offset + 3] |
-      0
-    ); // Ensure signed
+    // Reuse the unsigned version and convert to a signed 32-bit integer.
+    // Bitwise OR with 0 forces the number into the Int32 range.
+    return DataParser.readUint32BE(data, offset) | 0;
   }
 
   /** Writes a big-endian 16-bit unsigned integer. */


### PR DESCRIPTION
## Summary
- Refactor DataParser.readInt32BE to reuse the unsigned helper and ensure signed 32-bit conversion
- Add unit tests covering 32-bit signed reads

## Testing
- `npm test --workspace=@m68k/memory`
- `npm run typecheck --workspace=@m68k/memory`
- `cmake -S . -B build` *(fails: missing vasm makefile during build)*

------
https://chatgpt.com/codex/tasks/task_e_68c131ad5714833192f820d7fc470411