### PR TITLE
Add override hook test for core system

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -160,6 +160,26 @@ describe('@m68k/core', () => {
     removeHook();
   });
 
+  it('should override execution at a given address', async () => {
+    const calls: number[] = [];
+    const overrideAddress = 0x408; // ADD.L #1, D1 instruction
+
+    const removeOverride = system.override(overrideAddress, sys => {
+      calls.push(sys.getRegisters().pc);
+      // Custom behavior: set D1 and jump to RTS
+      sys.setRegister('d1', 0x42);
+      sys.setRegister('pc', 0x40e); // Address of RTS instruction
+    });
+
+    await system.run(100);
+
+    expect(calls.length).toBe(1);
+    expect(system.getRegisters().d1).toBe(0x42);
+    expect(system.getRegisters().pc).toBe(0x40e);
+
+    removeOverride();
+  });
+
   it('should check tracer availability', () => {
     const tracer = system.tracer;
     expect(tracer).toBeDefined();


### PR DESCRIPTION
## Summary
- add unit test for overriding execution at a specific address in `@m68k/core`

## Testing
- `npm test` *(fails: Cannot find module './musashi-node.out.mjs')*
- `npm run typecheck` *(fails: Cannot find module '@m68k/core')*
- `cmake -S . -B build && cmake --build build` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13220f79083319d71dd0b262e25e3