### PR TITLE
Honor address filter for JS probe callbacks

### DIFF
--- a/musashi-wasm-test/tests/probe_filtering.test.js
+++ b/musashi-wasm-test/tests/probe_filtering.test.js
@@ -1,0 +1,73 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Ensure WASM module exists
+const modulePath = path.resolve(__dirname, '../../musashi-node.out.mjs');
+if (!fs.existsSync(modulePath)) {
+  console.error(`Missing WASM module at ${modulePath}. Build via ./build.fish`);
+  process.exit(1);
+}
+
+import createMusashiModule from '../load-musashi.js';
+
+describe('JS probe respects address filtering', () => {
+  let Module;
+  const PROG_START = 0x400;
+
+  beforeAll(async () => {
+    Module = await createMusashiModule();
+    expect(Module).toBeDefined();
+  });
+
+  beforeEach(() => {
+    Module._m68k_init();
+    Module.ccall('clear_regions', 'void', [], []);
+  });
+
+  it('calls probe only for filtered PCs', () => {
+    const MEM_SIZE = 0x2000;
+    const memPtr = Module._malloc(MEM_SIZE);
+    const mem = Module.HEAPU8.subarray(memPtr, memPtr + MEM_SIZE);
+
+    try {
+      // Map region
+      Module.ccall('add_region', 'void', ['number', 'number', 'number'], [0, MEM_SIZE, memPtr]);
+
+      // Reset vectors
+      mem[0] = 0x00; mem[1] = 0x00; mem[2] = 0x10; mem[3] = 0x00; // SP
+      mem[4] = 0x00; mem[5] = 0x00; mem[6] = 0x04; mem[7] = 0x00; // PC -> 0x400
+
+      // Program: 6 NOPs starting at 0x400 (PC values: 0x400,0x402,...,0x40A)
+      for (let i = 0; i < 6; i++) {
+        mem[PROG_START + 2 * i] = 0x4E; // NOP
+        mem[PROG_START + 2 * i + 1] = 0x71;
+      }
+
+      // Set JS probe
+      let calls = [];
+      const probeFunc = Module.addFunction((pc) => { calls.push(pc); return 0; }, 'ii');
+      Module.ccall('set_probe_callback', 'void', ['number'], [probeFunc]);
+
+      // Filter to only one PC: 0x404
+      Module.ccall('add_pc_hook_addr', 'void', ['number'], [0x404]);
+
+      // Reset and run
+      Module._m68k_pulse_reset();
+      Module._m68k_execute(100);
+
+      // Expect probe called only for filtered address
+      const unique = [...new Set(calls)];
+      expect(unique).toEqual([0x404]);
+
+      Module.removeFunction(probeFunc);
+    } finally {
+      Module._free(memPtr);
+      Module.ccall('clear_regions', 'void', [], []);
+    }
+  });
+});
+

--- a/myfunc.cc
+++ b/myfunc.cc
@@ -416,10 +416,14 @@ int my_instruction_hook_function(unsigned int pc_raw) {
     }
   }
   
-  // Call JS probe callback if registered
+  // Call JS probe callback if registered, honoring address filter semantics
   if (js_probe_callback) {
-    int js_result = js_probe_callback(pc);
-    if (js_result != 0) return js_result;  // JS wants to break
+    // When no filter is configured, probe all PCs; otherwise, only probe listed PCs
+    bool should_probe = _pc_hook_addrs.empty() || (_pc_hook_addrs.find(pc) != _pc_hook_addrs.end());
+    if (should_probe) {
+      int js_result = js_probe_callback(pc);
+      if (js_result != 0) return js_result;  // JS wants to break
+    }
   }
   
   // Call existing PC hook system


### PR DESCRIPTION
This PR makes the JS probe callback respect the configured address filter.

Summary
- myfunc.cc: Call  only when no filter is set or when  is present in  — matching legacy hook filtering.
- Adds WASM integration test  that runs a sequence of NOPs and asserts the probe is invoked only for the filtered PC (0x404).

Why
- Previously, the JS probe ran on every instruction regardless of , causing unnecessary overhead and surprising behavior.

Impact
- No change to behavior when no filter is configured (probe-all); with filters, calls are reduced to the specified PCs.
