### PR TITLE
Guard TS memory end-of-buffer accesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,43 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `m68k*.c/h`, `myfunc.cc`, `m68ktrace.cc`: Core emulator and WASM bridge (C/C++).
-- `packages/core`, `packages/memory`: TypeScript API packages published via workspaces.
-- `npm-package/`: Standalone npm package wrapper and generated artifacts.
-- `tests/`: CMake/GoogleTest C++ tests; `.cpp` plus helper headers.
-- `musashi-wasm-test/`: JS/Node integration tests for WASM builds.
-- `third_party/`: External deps (e.g., Perfetto, protobuf, vasm).
+- Core emulator and WASM bridge (C/C++): `m68k*.c/h`, `myfunc.cc`, `m68ktrace.cc`.
+- TypeScript packages: `packages/core`, `packages/memory` (published via workspaces).
+- NPM wrapper & artifacts: `npm-package/`.
+- C++ tests: `tests/` (CMake/GoogleTest).
+- WASM integration tests: `musashi-wasm-test/`.
+- External deps: `third_party/` (Perfetto, protobuf, vasm).
+
+## Architecture Overview
+- Musashi 680x0 core powers CPU emulation; C sources target native and WASM via Emscripten.
+- A thin C/WASM bridge exposes the emulator API; `@m68k/core` wraps it for TypeScript, with memory helpers in `@m68k/memory`.
+- Optional tracing hooks emit Perfetto events when built with `ENABLE_PERFETTO=1`.
+- `npm-package/` distributes prebuilt WASM/JS bindings for Node and browsers.
 
 ## Build, Test, and Development Commands
-- Install deps: `npm install`
-- Build TS workspaces: `npm run build`
-- Test TS workspaces: `npm test` (e.g., `npm test --workspace=@m68k/core`)
-- Type check: `npm run typecheck`
-- Build WASM (standard): `./build.fish` or `./build_wasm_simple.sh`
-- Build WASM with Perfetto: `ENABLE_PERFETTO=1 ./build.fish`
-- Native CMake tests: `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`
-- Package wrapper build: `cd npm-package && npm run build`
+- Install deps: `npm install`.
+- Build TS workspaces: `npm run build`.
+- Test TS: `npm test` (e.g., `npm test --workspace=@m68k/core`).
+- Type check: `npm run typecheck` (runs `tsc --noEmit`).
+- Build WASM: `./build.fish` or `./build_wasm_simple.sh`.
+- Build WASM with Perfetto: `ENABLE_PERFETTO=1 ./build.fish`.
+- Native C++ tests: `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`.
+- Package wrapper: `cd npm-package && npm run build`.
 
 ## Coding Style & Naming Conventions
-- TypeScript: ES2020, strict types, modules via workspaces. Use `camelCase` for functions/variables, `PascalCase` for types. Tests end with `.test.ts` and live near `src`.
-- C/C++: C++17/C99; warnings enabled. Match existing file patterns (`snake_case` filenames, small, focused units). Prefer clear ownership over macros.
-- Formatting/Linting: No repo-wide linter configured; keep diffs minimal and consistent. Use `tsc --noEmit` to catch type issues before PRs.
+- TypeScript: ES2020 modules, strict types. `camelCase` for functions/vars, `PascalCase` for types. Tests end with `.test.ts` near `src`.
+- C/C++: C++17/C99. Filenames `snake_case`. Prefer small, focused units; clear ownership over macros. Warnings enabled; fix new warnings.
+- Formatting: No repo-wide linter; keep diffs minimal and consistent.
 
 ## Testing Guidelines
-- TypeScript: Jest with ts-jest. Place tests as `**/*.test.ts`. Example: `npm test --workspace=@m68k/memory`.
-- C++: GoogleTest via CMake/CTest. Build and run with the native CMake commands above. Perfetto-specific tests require `ENABLE_PERFETTO=ON` and protobuf setup.
-- Aim for tests that cover register access, memory hooks, and basic execution paths. Include failure cases (invalid addresses, tracing off/on).
+- TypeScript: Jest via ts-jest. Place tests as `**/*.test.ts`. Aim to cover register access, memory hooks, basic execution; include failure cases.
+- C++: GoogleTest via CMake/CTest. Perfetto-specific tests require `ENABLE_PERFETTO=ON` and protobuf/abseil (see `build_protobuf_wasm.sh`).
 
 ## Commit & Pull Request Guidelines
-- Commits: Imperative mood, concise scope (e.g., "Fix M68000 exception handling", "Add TS wrapper for tracing"). Squash noise; group related changes.
-- PRs: Include a clear description, linked issues, and test evidence (commands run, output, or screenshots when relevant). Ensure `npm test`, `npm run typecheck`, and CMake tests pass. Note changes affecting `npm-package/` or WASM artifacts.
+- Commits: Imperative, scoped (e.g., “Fix M68000 exception handling”, “Add TS wrapper for tracing”). Squash noise; group related changes.
+- PRs: Include clear description, linked issues, and test evidence (commands run, output/screenshots). Ensure `npm test`, `npm run typecheck`, and CMake tests pass. Note changes affecting `npm-package/` or `packages/core/wasm`.
 
 ## Security & Configuration Tips
-- Tooling: Emscripten SDK required for WASM; Node 16+; CMake for native. Set `ENABLE_PERFETTO=1` only when protobuf/abseil are built (see `build_protobuf_wasm.sh`). Avoid committing generated binaries except where expected (`npm-package/dist`, `packages/core/wasm`).
-
+- Requirements: Emscripten SDK (for WASM), Node 16+, CMake.
+- Enable Perfetto only when protobuf/abseil are built.
+- Avoid committing generated binaries except `npm-package/dist` and `packages/core/wasm`.

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -90,6 +90,22 @@ describe('@m68k/core', () => {
     expect(system.read(ramBase + 6, 2)).toBe(0xcdef);
   });
 
+  it('respects memory bounds for multi-byte access', () => {
+    const ramBase = 0x100000;
+    const ramSize = 0x1000;
+
+    // Single byte at last address should work
+    system.write(ramBase + ramSize - 1, 1, 0xAB);
+    expect(system.read(ramBase + ramSize - 1, 1)).toBe(0xAB);
+
+    // Multi-byte read/write crossing end should be safely ignored / return 0
+    system.write(ramBase + ramSize - 1, 2, 0xCDEF);
+    expect(system.read(ramBase + ramSize - 1, 2)).toBe(0);
+
+    system.write(ramBase + ramSize - 2, 4, 0x11223344);
+    expect(system.read(ramBase + ramSize - 2, 4)).toBe(0);
+  });
+
   it('should read and write byte arrays', () => {
     const ramBase = 0x100000;
     const data = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]);

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -275,6 +275,7 @@ export class MusashiWrapper {
   read_memory(address: number, size: 1 | 2 | 4): number {
     // Read from our unified memory (big-endian composition)
     if (address >= this._memory.length) return 0;
+    if (address + size > this._memory.length) return 0;
 
     if (size === 1) {
       return this._memory[address];
@@ -293,6 +294,7 @@ export class MusashiWrapper {
   write_memory(address: number, size: 1 | 2 | 4, value: number) {
     // Write to our unified memory (big-endian decomposition)
     if (address >= this._memory.length) return;
+    if (address + size > this._memory.length) return;
 
     if (size === 1) {
       this._memory[address] = value & 0xff;


### PR DESCRIPTION
This PR adds explicit end-bound checks to the MusashiWrapper TS memory helpers.

Summary
- Ensures read_memory/write_memory return 0 or no-op when address + size would exceed the typed array length.
- Adds Jest test in packages/core/src/index.test.ts asserting multi-byte ops at the last byte are safe.

Why
- Avoids partial writes/reads and undefined values when crossing array bounds.

How To Test
- npm install
- npm test --workspace=@m68k/core
