### PR TITLE
Refactor tracer symbol registration

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,25 +104,29 @@ class TracerImpl implements Tracer {
     return Promise.resolve(traceData);
   }
 
-  registerFunctionNames(symbols: SymbolMap): void {
+  private _registerSymbols(
+    symbols: SymbolMap,
+    register: (addr: number, name: string) => void
+  ): void {
     if (!this.isAvailable()) return;
-    for (const address in symbols) {
-      // Ensure address is a number, as keys can be strings
+    for (const [address, name] of Object.entries(symbols)) {
       const addrNum = Number(address);
-      if (!isNaN(addrNum)) {
-        this._musashi.registerFunctionName(addrNum, symbols[address]);
+      if (!Number.isNaN(addrNum)) {
+        register(addrNum, name);
       }
     }
   }
 
+  registerFunctionNames(symbols: SymbolMap): void {
+    this._registerSymbols(symbols, (addr, name) =>
+      this._musashi.registerFunctionName(addr, name)
+    );
+  }
+
   registerMemoryNames(symbols: SymbolMap): void {
-    if (!this.isAvailable()) return;
-    for (const address in symbols) {
-      const addrNum = Number(address);
-      if (!isNaN(addrNum)) {
-        this._musashi.registerMemoryName(addrNum, symbols[address]);
-      }
-    }
+    this._registerSymbols(symbols, (addr, name) =>
+      this._musashi.registerMemoryName(addr, name)
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate symbol loops by centralizing registration in Tracer

## Testing
- `npm test` *(fails: Cannot find module './musashi-node.out.mjs')*
- `npm run typecheck` *(fails: Cannot find module '@m68k/core')*
- `cmake -S . -B build` *(passes)*
- `cmake --build build` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2097accdc83319dd9e67357dacf88