### PR TITLE
Remove redundant Promise.resolve in core API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,7 +101,7 @@ class TracerImpl implements Tracer {
       throw new Error('Failed to export Perfetto trace data.');
     }
 
-    return Promise.resolve(traceData);
+    return traceData;
   }
 
   private _registerSymbols(
@@ -189,11 +189,11 @@ class SystemImpl implements System {
   }
 
   async call(address: number): Promise<number> {
-    return Promise.resolve(this._musashi.call(address));
+    return this._musashi.call(address);
   }
 
   async run(cycles: number): Promise<number> {
-    return Promise.resolve(this._musashi.execute(cycles));
+    return this._musashi.execute(cycles);
   }
 
   reset(): void {


### PR DESCRIPTION
## Summary
- eliminate unnecessary `Promise.resolve` calls in core async methods to simplify code

## Testing
- `npm test` *(fails: Cannot find module './musashi-node.out.mjs')*
- `npm run typecheck` *(fails: Cannot find module '@m68k/core')*
- `cmake -S . -B build`
- `cmake --build build` *(fails: No targets specified and no makefile found for vasm)*
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68c2097accdc83319dd9e67357dacf88