### PR TITLE
feat(step): add exact single-instruction execution and TS System.step()

### DIFF
--- a/build.fish
+++ b/build.fish
@@ -161,6 +161,8 @@ set -l exported_functions \
     \
     _m68k_get_last_break_reason \
     _m68k_reset_last_break_reason
+    \
+    _m68k_step_one
 
 # Add Perfetto functions only if enabled
 if test "$enable_perfetto" = "1"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,6 +205,10 @@ class SystemImpl implements System {
     return this._musashi.execute(cycles);
   }
 
+  async step(): Promise<number> {
+    return this._musashi.step();
+  }
+
   reset(): void {
     this._musashi.pulse_reset();
   }

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -9,6 +9,7 @@ export interface MusashiEmscriptenModule {
   _add_pc_hook_addr(addr: number): void;
   _add_region(start: number, len: number, buf: EmscriptenBuffer): void;
   _m68k_execute(cycles: number): number;
+  _m68k_step_one(): number;
   _m68k_get_reg(context: number, index: number): number;
   _m68k_init(): void;
   _m68k_pulse_reset(): void;
@@ -202,6 +203,10 @@ export class MusashiWrapper {
 
   execute(cycles: number): number {
     return this._module._m68k_execute(cycles);
+  }
+
+  step(): number {
+    return this._module._m68k_step_one();
   }
 
   private requireExport<K extends keyof MusashiEmscriptenModule>(name: K): void {

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -1,0 +1,61 @@
+// Single-instruction stepping tests using real WASM
+import { createSystem } from './index.js';
+import type { System } from './types.js';
+
+describe('@m68k/core step()', () => {
+  let system: System;
+
+  beforeEach(async () => {
+    // Minimal ROM with reset vectors and a tiny program at 0x400
+    const rom = new Uint8Array(0x1000);
+
+    // Initial SSP = 0x00010000
+    rom[0] = 0x00;
+    rom[1] = 0x01;
+    rom[2] = 0x00;
+    rom[3] = 0x00;
+    // Initial PC = 0x00000400
+    rom[4] = 0x00;
+    rom[5] = 0x00;
+    rom[6] = 0x04;
+    rom[7] = 0x00;
+
+    // Program at 0x400:
+    // 0x400: MOVE.L #$12345678, D0   (6 bytes)
+    rom[0x400] = 0x20; rom[0x401] = 0x3c;
+    rom[0x402] = 0x12; rom[0x403] = 0x34; rom[0x404] = 0x56; rom[0x405] = 0x78;
+    // 0x406: MOVE.L D0, (A0)         (2 bytes)
+    rom[0x406] = 0x20; rom[0x407] = 0x80;
+    // 0x408: ADD.L #1, D1            (6 bytes)
+    rom[0x408] = 0x06; rom[0x409] = 0x81; rom[0x40a] = 0x00; rom[0x40b] = 0x00; rom[0x40c] = 0x00; rom[0x40d] = 0x01;
+    // 0x40E: RTS                     (2 bytes)
+    rom[0x40e] = 0x4e; rom[0x40f] = 0x75;
+
+    system = await createSystem({ rom, ramSize: 0x1000 });
+  });
+
+  it('executes exactly one instruction and advances PC', async () => {
+    const regs0 = system.getRegisters();
+    expect(regs0.pc >>> 0).toBe(0x400);
+
+    const c1 = await system.step();
+    expect(c1).toBeGreaterThan(0);
+    const regs1 = system.getRegisters();
+    expect(regs1.pc >>> 0).toBe(0x406); // 6-byte immediate MOVE
+    expect(regs1.d0 >>> 0).toBe(0x12345678);
+
+    // Ensure next step advances by 2 bytes for MOVE.L D0,(A0)
+    system.setRegister('a0', 0x100000);
+    const c2 = await system.step();
+    expect(c2).toBeGreaterThan(0);
+    const regs2 = system.getRegisters();
+    expect(regs2.pc >>> 0).toBe(0x408);
+
+    // Next step should skip 6-byte ADD.L #1,D1
+    const c3 = await system.step();
+    expect(c3).toBeGreaterThan(0);
+    const regs3 = system.getRegisters();
+    expect(regs3.pc >>> 0).toBe(0x40e);
+  });
+});
+

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,6 +121,12 @@ export interface System {
    */
   run(cycles: number): Promise<number>;
 
+  /**
+   * Executes exactly one instruction and stops before the next one.
+   * @returns The number of CPU cycles consumed by the instruction.
+   */
+  step(): Promise<number>;
+
   /** Resets the CPU to its initial state. */
   reset(): void;
 


### PR DESCRIPTION
Summary
- Add precise single-instruction stepping across C++/WASM/TS APIs.
- New C++ export `_m68k_step_one()` executes exactly one instruction and returns cycles.
- Expose stepping in TypeScript via `system.step(): Promise<number>`.
- Add Jest tests validating PC progression by instruction size.

Details
- C++ (myfunc.cc):
  - Introduce StepState in the instruction hook path with priority handling:
    - `Arm` on first hook (current instruction), `BreakNext` on the next hook (before next instruction executes), then `Idle`.
  - Add `BreakReason::Step` for diagnostics.
  - New `unsigned long long m68k_step_one()` function which arms step and calls `m68k_execute()` with a generous timeslice; the hook ends the timeslice deterministically.
- WASM build (build.fish):
  - Export `_m68k_step_one`.
- TS core:
  - `MusashiWrapper.step()` delegates to `_m68k_step_one`.
  - `System` interface extended with `step(): Promise<number>`; `SystemImpl` implements it.
- Tests:
  - `packages/core/src/step.test.ts` verifies successive `step()` calls advance PC by 6, 2, 6 bytes for the sample program and that cycles > 0. Also checks register changes (D0 set by first instruction).

Why
- Users need deterministic single-instruction stepping, not cycle-based stepping. `m68k_execute(1)` is 1 cycle, not 1 instruction. This PR introduces a robust, cross-layer step API.

Build & Test
- Build WASM and run tests end-to-end:
  - `./test_with_real_wasm.sh`
  - Optional: `ENABLE_PERFETTO=1 ./test_with_real_wasm.sh`
- Or ensure `packages/core/wasm/` has current `musashi-node.out.*` artifacts, then:
  - `npm test --workspace=@m68k/core`

Notes
- Docs additions for the new `system.step()` can be done in a follow-up.
- The step mechanism gives priority to stepping over other hook-triggered breaks to guarantee exactly one instruction executes.
