### PR TITLE
feat(core): add onMemoryRead/onMemoryWrite with PC context

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,17 @@ export interface CpuRegisters {
 /** A function to be executed when a specific address is hit during execution. */
 export type HookCallback = (system: System) => void;
 
+/** Memory access event payload for JS callbacks. */
+export interface MemoryAccessEvent {
+  addr: number;
+  size: 1 | 2 | 4;
+  value: number;
+  pc: number;
+}
+
+/** Callback invoked on traced memory access. */
+export type MemoryAccessCallback = (event: MemoryAccessEvent) => void;
+
 /** Configuration for creating a new System instance. */
 export interface SystemConfig {
   /** The ROM data for the system. */
@@ -149,4 +160,18 @@ export interface System {
 
   /** Disassembles a single instruction at the given address and returns a formatted string (or null if unavailable). */
   disassemble(address: number): string | null;
+
+  /**
+   * Register a callback for memory reads performed by the CPU. The callback receives
+   * the accessed address, size (1/2/4), value read, and the PC of the instruction.
+   * Returns a function to unsubscribe.
+   */
+  onMemoryRead(cb: MemoryAccessCallback): () => void;
+
+  /**
+   * Register a callback for memory writes performed by the CPU. The callback receives
+   * the accessed address, size (1/2/4), value written, and the PC of the instruction.
+   * Returns a function to unsubscribe.
+   */
+  onMemoryWrite(cb: MemoryAccessCallback): () => void;
 }


### PR DESCRIPTION
This PR adds PC-aware memory access callbacks to the @m68k/core API and tests.\n\nChanges\n- System.onMemoryRead/Write(cb) with payload { addr, size, value, pc }\n- musashi-wrapper bridges m68k_trace_mem_hook -> JS, toggled automatically when there are subscribers\n- Unit test validates write (MOVE.L D0,-(SP)) and read (MOVE.L (SP)+,D1) with expected PC, address, size, and value\n\nBuild/Runtime\n- Uses existing exported tracing symbols (_m68k_set_trace_mem_callback, _m68k_trace_enable, _m68k_trace_set_mem_enabled)\n- No changes to build scripts; functionality is a no-op if symbols are absent\n\nWhy\n- Enables real-time JS visibility into memory accesses with PC context, without parsing Perfetto traces.\n\nTest\n- npm test --workspace=@m68k/core\n