### PR TITLE
feat(core): add getInstructionSize(pc) + tests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,6 +163,10 @@ class SystemImpl implements System {
     if (!one) return null;
     return one.text;
     }
+  getInstructionSize(pc: number): number {
+    const one = this._musashi.disassemble(pc >>> 0);
+    return one ? (one.size >>> 0) : 0;
+  }
   read(address: number, size: 1 | 2 | 4): number {
     return this._musashi.read_memory(address, size);
   }

--- a/packages/core/src/instruction-size.test.ts
+++ b/packages/core/src/instruction-size.test.ts
@@ -1,0 +1,46 @@
+import { createSystem } from './index';
+
+describe('getInstructionSize', () => {
+  it('returns correct sizes for common instructions', async () => {
+    const rom = new Uint8Array(0x4000);
+    const sys = await createSystem({ rom, ramSize: 0x20000 });
+
+    // NOP at 0x0600 (0x4E71) -> 2 bytes
+    sys.write(0x600, 1, 0x4e);
+    sys.write(0x601, 1, 0x71);
+    expect(sys.getInstructionSize(0x600)).toBe(2);
+
+    // RTS at 0x0602 (0x4E75) -> 2 bytes
+    sys.write(0x602, 1, 0x4e);
+    sys.write(0x603, 1, 0x75);
+    expect(sys.getInstructionSize(0x602)).toBe(2);
+
+    // MOVEQ #$7f, D3 at 0x0800 (0x73 0x7f) -> 2 bytes
+    sys.write(0x800, 1, 0x73);
+    sys.write(0x801, 1, 0x7f);
+    expect(sys.getInstructionSize(0x800)).toBe(2);
+
+    // LINK A6,#-$8 at 0x0810 (0x4e 0x56 0xff 0xf8) -> 4 bytes
+    sys.write(0x810, 1, 0x4e);
+    sys.write(0x811, 1, 0x56);
+    sys.write(0x812, 1, 0xff);
+    sys.write(0x813, 1, 0xf8);
+    expect(sys.getInstructionSize(0x810)).toBe(4);
+
+    // ADDI.L #$1, D1 at 0x0860 -> 6 bytes
+    const addi = [0x06, 0x81, 0x00, 0x00, 0x00, 0x01];
+    for (let i = 0; i < addi.length; i++) sys.write(0x860 + i, 1, addi[i]);
+    expect(sys.getInstructionSize(0x860)).toBe(6);
+
+    // JSR $00000600 at 0x0900 (absolute long) -> 6 bytes
+    const jsrAbsLong = [0x4e, 0xb9, 0x00, 0x00, 0x06, 0x00];
+    for (let i = 0; i < jsrAbsLong.length; i++) sys.write(0x900 + i, 1, jsrAbsLong[i]);
+    expect(sys.getInstructionSize(0x900)).toBe(6);
+
+    // DBRA D0,$87e at 0x0A00 -> 4 bytes
+    const dbra = [0x51, 0xc8, 0xff, 0xfe];
+    for (let i = 0; i < dbra.length; i++) sys.write(0xa00 + i, 1, dbra[i]);
+    expect(sys.getInstructionSize(0xa00)).toBe(4);
+  });
+});
+

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -162,6 +162,12 @@ export interface System {
   disassemble(address: number): string | null;
 
   /**
+   * Returns the size in bytes of the instruction at the given PC.
+   * Returns 0 if the disassembler is unavailable or decoding fails.
+   */
+  getInstructionSize(pc: number): number;
+
+  /**
    * Register a callback for memory reads performed by the CPU. The callback receives
    * the accessed address, size (1/2/4), value read, and the PC of the instruction.
    * Returns a function to unsubscribe.


### PR DESCRIPTION
This PR adds a small TS/JS API to query the instruction size at a given PC and covers it with unit tests.\n\nChanges\n- System.getInstructionSize(pc: number): number — returns byte length (0 on failure/unavailable)\n- Implementation delegates to the existing disassembler export (_m68k_disassemble) already used by musashi-wrapper\n- New tests in @m68k/core validate sizes for common opcodes: NOP/RTS (2), LINK (4), ADDI.L imm32 (6), JSR abs.l (6), DBRA (4)\n\nWhy\n- Useful for stepping, instrumentation, and building higher-level tooling that needs to know how far to advance PC when decoding instructions from memory.\n\nTesting\n- npm test --workspace=@m68k/core\n