### PR TITLE
core: return metadata from System.step()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ const cycles = await system.run(1000);
 // Access registers
 const regs = system.getRegisters();
 console.log(`D0: 0x${regs.d0.toString(16)}`);
+ 
+// Single-step one instruction and inspect metadata
+const { cycles: c1, startPc, endPc } = await system.step();
+console.log(`Stepped ${c1} cycles from 0x${startPc.toString(16)} to 0x${endPc.toString(16)}`);
 ```
 
 ### Building from Source

--- a/packages/README.md
+++ b/packages/README.md
@@ -52,6 +52,16 @@ const statusReg = new MemoryRegion(
 const status = statusReg.get();
 ```
 
+### Single-step execution
+
+Execute exactly one instruction and inspect precise PCs and cycles:
+
+```ts
+const { cycles, startPc, endPc, ppc } = await system.step();
+console.log(`Stepped ${cycles} cycles from 0x${startPc.toString(16)} to 0x${endPc.toString(16)}`);
+// ppc is provided by the core and usually equals startPc
+```
+
 ## Perfetto Tracing
 
 If the WASM module is built with Perfetto support (`ENABLE_PERFETTO=1`), you can capture performance traces:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,8 +205,13 @@ class SystemImpl implements System {
     return this._musashi.execute(cycles);
   }
 
-  async step(): Promise<number> {
-    return this._musashi.step();
+  async step(): Promise<{ cycles: number; startPc: number; endPc: number; ppc?: number }> {
+    const startPc = this._musashi.get_reg(16) >>> 0; // PC before executing
+    const cycles = this._musashi.step() >>> 0;
+    const endPc = this._musashi.get_reg(16) >>> 0; // PC after executing
+    // Previous PC as reported by the core; may equal startPc
+    const ppc = this._musashi.get_reg(19) >>> 0;
+    return { cycles, startPc, endPc, ppc };
   }
 
   reset(): void {

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -38,24 +38,29 @@ describe('@m68k/core step()', () => {
     const regs0 = system.getRegisters();
     expect(regs0.pc >>> 0).toBe(0x400);
 
-    const c1 = await system.step();
-    expect(c1).toBeGreaterThan(0);
+    const s1 = await system.step();
+    expect(s1.cycles).toBeGreaterThan(0);
+    expect(s1.startPc >>> 0).toBe(0x400);
+    expect(s1.endPc >>> 0).toBe(0x406);
     const regs1 = system.getRegisters();
     expect(regs1.pc >>> 0).toBe(0x406); // 6-byte immediate MOVE
     expect(regs1.d0 >>> 0).toBe(0x12345678);
 
     // Ensure next step advances by 2 bytes for MOVE.L D0,(A0)
     system.setRegister('a0', 0x100000);
-    const c2 = await system.step();
-    expect(c2).toBeGreaterThan(0);
+    const s2 = await system.step();
+    expect(s2.cycles).toBeGreaterThan(0);
+    expect(s2.startPc >>> 0).toBe(0x406);
+    expect(s2.endPc >>> 0).toBe(0x408);
     const regs2 = system.getRegisters();
     expect(regs2.pc >>> 0).toBe(0x408);
 
     // Next step should skip 6-byte ADD.L #1,D1
-    const c3 = await system.step();
-    expect(c3).toBeGreaterThan(0);
+    const s3 = await system.step();
+    expect(s3.cycles).toBeGreaterThan(0);
+    expect(s3.startPc >>> 0).toBe(0x408);
+    expect(s3.endPc >>> 0).toBe(0x40e);
     const regs3 = system.getRegisters();
     expect(regs3.pc >>> 0).toBe(0x40e);
   });
 });
-

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -123,9 +123,13 @@ export interface System {
 
   /**
    * Executes exactly one instruction and stops before the next one.
-   * @returns The number of CPU cycles consumed by the instruction.
+   * Returns execution metadata for the instruction.
+   * - cycles: CPU cycles consumed by the instruction
+   * - startPc: PC at instruction start
+   * - endPc: PC after instruction completes
+   * - ppc: optional previous PC reported by the core (usually equals startPc)
    */
-  step(): Promise<number>;
+  step(): Promise<{ cycles: number; startPc: number; endPc: number; ppc?: number }>;
 
   /** Resets the CPU to its initial state. */
   reset(): void;


### PR DESCRIPTION
This PR updates the public TypeScript API of `@m68k/core` to return richer information from `System.step()`:

API change
- Old: `step(): Promise<number>`
- New: `step(): Promise<{ cycles: number; startPc: number; endPc: number; ppc?: number }>`

Details
- `cycles`: CPU cycles consumed by the single instruction
- `startPc`: Program Counter before executing the instruction
- `endPc`: Program Counter after executing the instruction
- `ppc`: Previous Program Counter reported by the core (usually equals `startPc`)

Implementation
- Read PC before and after `_m68k_step_one()`; read PPC from `M68K_REG_PPC` (index 19).
- No changes to the WASM bridge required.
- Updated unit test `step.test.ts` to assert new shape and PC progression.

Impact
- Breaking change: Callers must use `const { cycles } = await system.step()` instead of relying on a numeric return.

Validation
- Ran `npm run typecheck` successfully.
- Jest tests require real WASM artifacts; use `./test_with_real_wasm.sh` or copy built artifacts into `packages/core/wasm/` before running `npm test`.

Follow-ups
- If you want, I can update any external docs/usages referencing the old `step()` signature.