### PR TITLE
Tidy build exports; bump retrobus-perfetto

### DIFF
--- a/build.fish
+++ b/build.fish
@@ -157,11 +157,9 @@ set -l exported_functions \
     _set_isp_reg \
     _set_usp_reg \
     _get_sp_reg \
-    _m68k_call_until_js_stop
-    \
+    _m68k_call_until_js_stop \
     _m68k_get_last_break_reason \
-    _m68k_reset_last_break_reason
-    \
+    _m68k_reset_last_break_reason \
     _m68k_step_one
 
 # Add Perfetto functions only if enabled


### PR DESCRIPTION
This PR makes two small maintenance changes:

- Keep trailing backslashes consistent in `build.fish` exported_functions list to avoid syntax mishaps.
- Update `third_party/retrobus-perfetto` submodule pointer.

Build/test guidance:
- TS build/tests: `npm run build && npm test`
- WASM: `./build.fish` (or `ENABLE_PERFETTO=1 ./build.fish`)

No functional changes expected beyond cleaner build script formatting.