### PR TITLE
Test: verify WASM exports match build.sh

### DIFF
--- a/musashi-wasm-test/tests/exports_from_build.test.js
+++ b/musashi-wasm-test/tests/exports_from_build.test.js
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Use the same loader the other tests rely on
+import createMusashiModule from '../load-musashi.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolve important paths relative to this test file
+const repoRoot = path.resolve(__dirname, '..', '..');
+const buildScriptPath = path.resolve(repoRoot, 'build.sh');
+const nodeWasmPath = path.resolve(repoRoot, 'musashi-node.out.mjs');
+
+// Small helper to extract clean symbol tokens from a block body
+function parseSymbolBlock(body) {
+  return body
+    .split('\n')
+    .map((line) => line.replace(/#.*/, '').trim()) // strip comments and whitespace
+    .filter((line) => line.length > 0)
+    .map((line) => line.replace(/^['\"]|['\"]$/g, '')); // remove surrounding quotes if any
+}
+
+function parseExportedFunctionsFromBuild(buildShContent) {
+  const base = [];
+  const perfettoExtras = [];
+
+  // Match both the base assignment and any subsequent "+=" append blocks
+  // Capture the operator (= vs +=) and the block content between parentheses
+  const re = /exported_functions\s*(\+?=)\s*\(([^)]*)\)/gms;
+  let m;
+  while ((m = re.exec(buildShContent)) !== null) {
+    const op = m[1];
+    const body = m[2] || '';
+    const symbols = parseSymbolBlock(body);
+    if (op === '=') base.push(...symbols);
+    else perfettoExtras.push(...symbols);
+  }
+
+  return { base, perfettoExtras };
+}
+
+describe('Export parity with build.sh', () => {
+  let Module;
+
+  beforeAll(async () => {
+    // Ensure artifacts exist to provide clearer failure messages
+    if (!fs.existsSync(buildScriptPath)) {
+      // Fail fast if repository layout is unexpected
+      throw new Error(`build.sh not found at ${buildScriptPath}`);
+    }
+    if (!fs.existsSync(nodeWasmPath)) {
+      // Keep message short; the existing integration test already prints guidance
+      throw new Error(`WASM module not found at ${nodeWasmPath}. Run ./build.sh first.`);
+    }
+
+    Module = await createMusashiModule();
+    expect(Module).toBeDefined();
+  });
+
+  it('exports all functions declared in build.sh', async () => {
+    const buildContent = fs.readFileSync(buildScriptPath, 'utf8');
+    const { base, perfettoExtras } = parseExportedFunctionsFromBuild(buildContent);
+
+    // Decide whether to include Perfetto-only exports.
+    // Prefer explicit env signal (mirrors build.sh), with a runtime fallback.
+    const envPerfetto = process.env.ENABLE_PERFETTO === '1';
+    const runtimePerfetto = perfettoExtras.some((name) => typeof Module[name] === 'function');
+    const includePerfetto = envPerfetto || runtimePerfetto;
+
+    const expected = includePerfetto ? [...base, ...perfettoExtras] : base;
+
+    // Validate that each expected symbol is present as a function on the Module.
+    // Collect any missing to produce a single, informative assertion.
+    const missing = [];
+    for (const name of expected) {
+      const val = Module[name];
+      if (typeof val !== 'function') {
+        missing.push(name);
+      }
+    }
+
+    if (missing.length > 0) {
+      // Provide a compact failure message with the missing symbols
+      throw new Error(
+        `Missing ${missing.length} exported functions from Module: ${missing.join(', ')}`
+      );
+    }
+  });
+});
+


### PR DESCRIPTION
This PR adds a Jest test that guarantees parity between the functions declared in `build.sh` and the functions actually exported on the Emscripten module at runtime.

What it does
- Parses `build.sh` for `exported_functions` (base list) and any `+=` append blocks used for Perfetto-only exports.
- Instantiates the Node ESM build via `musashi-wasm-test/load-musashi.js`.
- Verifies each declared export exists on `Module` as a function.
- Perfetto handling: includes Perfetto-only symbols if `ENABLE_PERFETTO=1` (mirroring `build.sh`) or if any `_m68k_perfetto_*` symbols are present at runtime.

Why
- Avoids hard-coding exported function names in tests.
- Automatically stays in sync when `build.sh` export lists change.
- Catches accidental omissions or regressions where a symbol is dropped from the final build.

Files
- `musashi-wasm-test/tests/exports_from_build.test.js`

How to validate locally
- Build the WASM artifacts: `./build.sh` (or `ENABLE_PERFETTO=1 ./build.sh`)
- Run the test suite in the integration package: `cd musashi-wasm-test && npm test`
- Or run the end-to-end helper: `./test_with_real_wasm.sh`

Notes
- The test fails fast with a clear error if `musashi-node.out.mjs` is missing (i.e., you haven’t built yet).
- Can extend later to also validate `EXPORTED_RUNTIME_METHODS` or `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE` if desired.
