### PR TITLE
Fix: normalize musashi.step() return in TS; update retrobus-perfetto submodule

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -215,7 +215,10 @@ class SystemImpl implements System {
 
   async step(): Promise<{ cycles: number; startPc: number; endPc: number; ppc?: number }> {
     const startPc = this._musashi.get_reg(16) >>> 0; // PC before executing
-    const cycles = this._musashi.step() >>> 0;
+    // musashi.step() may return an unsigned long long (BigInt with WASM_BIGINT)
+    // Normalize to Number before masking to avoid BigInt/Number mixing.
+    const c = this._musashi.step();
+    const cycles = Number(c) >>> 0;
     const endPc = this._musashi.get_reg(16) >>> 0; // PC after executing
     // Previous PC as reported by the core; may equal startPc
     const ppc = this._musashi.get_reg(19) >>> 0;


### PR DESCRIPTION
Summary\n- Normalize musashi.step() return to Number in @m68k/core TypeScript wrapper to avoid BigInt/Number mixing when built with WASM_BIGINT.\n- Update third_party/retrobus-perfetto submodule to latest (8ed36e7).\n\nDetails\n- Wrap step() return in Number() before unsigned mask (>>> 0) to ensure consistent behavior across builds.\n- Submodule bump includes minor fixes for WASM compatibility and housekeeping.\n\nTesting\n- Ran npm install and npm run typecheck: passed.\n- Did not run native C++ tests or WASM build in this PR.\n\nImpact\n- Affects packages/core execution step path; no API changes.\n- No changes to npm-package artifacts included.