### PR TITLE
tests(step_one): add JSR single-step test that skips over following instructions

### DIFF
--- a/myfunc.cc
+++ b/myfunc.cc
@@ -457,8 +457,6 @@ extern "C" {
       }
     }
 
-    // Normalize PPC to the start of the stepped instruction for stable semantics
-    m68k_set_reg(M68K_REG_PPC, start_pc);
     // Normalize PC to computed next-instruction boundary
     m68k_set_reg(M68K_REG_PC, new_pc);
 

--- a/myfunc.cc
+++ b/myfunc.cc
@@ -457,6 +457,8 @@ extern "C" {
       }
     }
 
+    // Normalize PPC to the start of the stepped instruction for stable semantics
+    m68k_set_reg(M68K_REG_PPC, start_pc);
     // Normalize PC to computed next-instruction boundary
     m68k_set_reg(M68K_REG_PC, new_pc);
 

--- a/tests/test_myfunc.cpp
+++ b/tests/test_myfunc.cpp
@@ -181,6 +181,16 @@ TEST_F(MyFuncTest, StepOneJsrSkipsOverFollowingInstructions) {
     // Subroutine target: RTS at 0x414
     write_word(0x414, 0x4E75);
 
+    // Validate disassembly text and sizes
+    EXPECT_EQ(M68kTestUtils::m68k_disassembly(0x400),
+              std::make_pair(std::string("jsr     $414.l"), 6));
+    EXPECT_EQ(M68kTestUtils::m68k_disassembly(0x406),
+              std::make_pair(std::string("move.l  #$aabbccdd, D0"), 6));
+    EXPECT_EQ(M68kTestUtils::m68k_disassembly(0x40C),
+              std::make_pair(std::string("nop"), 2));
+    EXPECT_EQ(M68kTestUtils::m68k_disassembly(0x414),
+              std::make_pair(std::string("rts"), 2));
+
     // Sanity: initial registers
     unsigned int sp0 = m68k_get_reg(NULL, M68K_REG_SP);
     unsigned int pc0 = m68k_get_reg(NULL, M68K_REG_PC);

--- a/tests/test_myfunc.cpp
+++ b/tests/test_myfunc.cpp
@@ -192,24 +192,18 @@ TEST_F(MyFuncTest, StepOneJsrSkipsOverFollowingInstructions) {
               std::make_pair(std::string("rts"), 2));
 
     // Sanity: initial registers
-    unsigned int sp0 = m68k_get_reg(NULL, M68K_REG_SP);
-    unsigned int pc0 = m68k_get_reg(NULL, M68K_REG_PC);
-    ASSERT_EQ(sp0, 0x1000u);
-    ASSERT_EQ(pc0, 0x400u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_SP), 0x1000u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x400u);
 
     // Step the JSR
     (void)m68k_step_one();
 
-    unsigned int sp1 = m68k_get_reg(NULL, M68K_REG_SP);
-    unsigned int pc1 = m68k_get_reg(NULL, M68K_REG_PC);
-    unsigned int ppc1 = m68k_get_reg(NULL, M68K_REG_PPC);
-
     // After JSR abs.l: PC points to target, PPC points to call site,
     // SP is decremented by 4 and contains the return address (0x406).
-    EXPECT_EQ(pc1, 0x414u);
-    EXPECT_EQ(ppc1, 0x400u);
-    EXPECT_EQ(sp1, 0x0FFCu);
-    EXPECT_EQ(read_long(sp1), 0x00000406u);
+    EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x414u);
+    EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_PPC), 0x400u);
+    EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_SP), 0x0FFCu);
+    EXPECT_EQ(read_long(m68k_get_reg(NULL, M68K_REG_SP)), 0x00000406u);
 
     // And the skipped instruction at 0x406 did not execute yet
     EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_D0), 0u);

--- a/tests/test_myfunc.cpp
+++ b/tests/test_myfunc.cpp
@@ -66,17 +66,14 @@ TEST_F(MyFuncTest, SingleStepNormalizesPcAndPpc) {
     EXPECT_EQ(M68kTestUtils::m68k_disassembly(0x406),
               std::make_pair(std::string("nop"), 2));
 
-    unsigned int start = m68k_get_reg(NULL, M68K_REG_PC);
-    ASSERT_EQ(start, 0x400u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x400u);
 
     unsigned long long cyc = m68k_step_one();
     EXPECT_EQ(cyc, 12ull) << "MOVE.L #imm32, D0 should take 12 cycles on 68000";
 
-    unsigned int end = m68k_get_reg(NULL, M68K_REG_PC);
-    unsigned int ppc = m68k_get_reg(NULL, M68K_REG_PPC);
     // Known encoding: MOVE.L #imm,D0 is 6 bytes, so end should be 0x406
-    EXPECT_EQ(end, 0x406u);
-    EXPECT_EQ(ppc, 0x400u);
+    EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x406u);
+    EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_PPC), 0x400u);
     // And D0 should have the immediate value
     EXPECT_EQ(m68k_get_reg(NULL, M68K_REG_D0), 0x12345678u);
 }
@@ -122,31 +119,21 @@ TEST_F(MyFuncTest, MemoryTraceCallbackInvokedOnWrite) {
     // Ensure SP is in a valid RAM range (base class set via reset vector)
     ASSERT_GT(m68k_get_reg(NULL, M68K_REG_SP), 0u);
 
-    unsigned int pc0 = m68k_get_reg(NULL, M68K_REG_PC);
-    unsigned int ppc0 = m68k_get_reg(NULL, M68K_REG_PPC);
-    unsigned int sp0 = m68k_get_reg(NULL, M68K_REG_SP);
-    ASSERT_EQ(pc0, 0x400u);
-    ASSERT_EQ(ppc0, 0x000000u);
-    ASSERT_EQ(sp0, 0x1000u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x400u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PPC), 0x000000u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_SP), 0x1000u);
 
     // Step the first two instructions to hit the write (second instruction)
     unsigned long long cyc1 = m68k_step_one(); // MOVE.L #imm, D0
-    unsigned int pc1 = m68k_get_reg(NULL, M68K_REG_PC);
-    unsigned int ppc1 = m68k_get_reg(NULL, M68K_REG_PPC);
-    unsigned int sp1 = m68k_get_reg(NULL, M68K_REG_SP);
-    unsigned int d0_1 = m68k_get_reg(NULL, M68K_REG_D0);
-    ASSERT_EQ(pc1, 0x406u);
-    ASSERT_EQ(ppc1, 0x400u);
-    ASSERT_EQ(sp1, 0x1000u);
-    ASSERT_EQ(d0_1, 0xCAFEBABEu);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x406u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PPC), 0x400u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_SP), 0x1000u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_D0), 0xCAFEBABEu);
 
     unsigned long long cyc2 = m68k_step_one(); // MOVE.L D0, -(SP)  -> triggers write
-    unsigned int pc2 = m68k_get_reg(NULL, M68K_REG_PC);
-    unsigned int ppc2 = m68k_get_reg(NULL, M68K_REG_PPC);
-    unsigned int sp2 = m68k_get_reg(NULL, M68K_REG_SP);
-    ASSERT_EQ(pc2, 0x408u);
-    ASSERT_EQ(ppc2, 0x406u);
-    ASSERT_EQ(sp2, 0x0FFCu);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PC), 0x408u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_PPC), 0x406u);
+    ASSERT_EQ(m68k_get_reg(NULL, M68K_REG_SP), 0x0FFCu);
 
     // Minimal assertion: memory trace callback was invoked at least once
     EXPECT_GT(write_calls, 0);


### PR DESCRIPTION
Adds a C++ test for the step_one API to validate JSR abs.l control flow.\n\n- Lays out a tiny program at 0x400:\n  - 0x400: JSR bash00414 (absolute long)\n  - 0x406: MOVE.L #, D0 (should be skipped)\n  - 0x40C: NOP (filler)\n  - 0x414: RTS (subroutine body)\n- Single-steps with m68k_step_one() and asserts:\n  - PC jumps to 0x414, PPC equals 0x400\n  - SP decremented by 4; [SP] == 0x00000406 (return address)\n  - D0 remains 0 (the post-JSR instruction at 0x406 didn’t execute yet)\n\nNotes:\n- Only tests are changed; no runtime code paths touched.\n- I could not run native tests locally here due to missing cmake in the environment. CI should validate.\n\nBuild & test locally:\n- cmake -S . -B build && cmake --build build\n- ctest --test-dir build --output-on-failure\n