### PR TITLE
CI: Add timeouts and stabilize Jest (forceExit, single worker)

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -66,6 +66,7 @@ jobs:
         run: cmake --build build --parallel $(nproc)
 
       - name: Run tests
+        timeout-minutes: 2
         working-directory: build
         run: ctest --output-on-failure -C ${{ matrix.build_type }}
 
@@ -106,6 +107,7 @@ jobs:
         run: cmake --build build-${{ matrix.sanitizer }} --parallel $(nproc)
 
       - name: Run tests
+        timeout-minutes: 2
         working-directory: build-${{ matrix.sanitizer }}
         env:
           ASAN_OPTIONS: detect_leaks=1:check_initialization_order=1

--- a/.github/workflows/wasm-ci.yml
+++ b/.github/workflows/wasm-ci.yml
@@ -131,6 +131,7 @@ jobs:
 
       # Run Node integration tests (repo's musashi-wasm-test)
       - name: Run Node.js integration tests
+        timeout-minutes: 3
         run: |
           cd musashi-wasm-test
           npm ci
@@ -138,6 +139,7 @@ jobs:
 
       # Run TypeScript tests (once per matrix entry, toggled by PERFETTO_ENABLED)
       - name: Run TypeScript tests
+        timeout-minutes: 3
         env:
           PERFETTO_ENABLED: ${{ matrix.perfetto && '1' || '0' }}
         run: |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run build --workspaces",
     "test": "npm run test --workspaces",
-    "test:ci": "npm run test:ci --workspaces",
+    "test:ci": "./run-tests-ci.sh",
     "test:core": "NODE_OPTIONS='--experimental-vm-modules' npx jest --projects packages/core --runInBand --verbose --no-cache",
     "clean": "npm run clean --workspaces",
     "typecheck": "npm run typecheck --workspaces",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "NODE_OPTIONS='--experimental-vm-modules' npx jest",
-    "test:ci": "NODE_OPTIONS='--experimental-vm-modules' npx jest --ci",
+    "test:ci": "NODE_OPTIONS='--experimental-vm-modules' npx jest --ci --forceExit --maxWorkers=1",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
@@ -42,6 +42,7 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "testTimeout": 10000,
     "extensionsToTreatAsEsm": [".ts"],
     "transform": {
       "^.+\\.ts$": [

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -15,7 +15,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "NODE_OPTIONS='--experimental-vm-modules' npx jest",
-    "test:ci": "NODE_OPTIONS='--experimental-vm-modules' npx jest --ci",
+    "test:ci": "NODE_OPTIONS='--experimental-vm-modules' npx jest --ci --forceExit --maxWorkers=1",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",

--- a/run-tests-ci.sh
+++ b/run-tests-ci.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running musashi-wasm CI tests..."
+
+# Run @m68k/memory tests (fast)
+echo "Running @m68k/memory tests..."
+if ! npm run test:ci --workspace=@m68k/memory; then
+  echo "@m68k/memory tests failed"
+  exit 1
+fi
+
+# Run @m68k/core tests with a soft timeout to avoid CI hangs
+echo "Running @m68k/core tests..."
+if command -v timeout >/dev/null 2>&1; then
+  if timeout 30s npm run test:ci --workspace=@m68k/core; then
+    echo "@m68k/core tests completed"
+  else
+    rc=$?
+    if [[ $rc -eq 124 ]]; then
+      echo "@m68k/core tests hit soft timeout (30s); treating as success to avoid hang"
+    else
+      echo "@m68k/core tests failed with exit code $rc"
+      exit $rc
+    fi
+  fi
+else
+  npm run test:ci --workspace=@m68k/core || true
+fi
+
+echo "All tests completed"
+

--- a/run-tests-ci.sh
+++ b/run-tests-ci.sh
@@ -5,29 +5,27 @@ set -euo pipefail
 echo "Running musashi-wasm CI tests..."
 
 # Run @m68k/memory tests (fast)
-echo "Running @m68k/memory tests..."
-if ! npm run test:ci --workspace=@m68k/memory; then
-  echo "@m68k/memory tests failed"
-  exit 1
-fi
-
-# Run @m68k/core tests with a soft timeout to avoid CI hangs
-echo "Running @m68k/core tests..."
+echo "Running @m68k/memory tests (30s timeout)..."
 if command -v timeout >/dev/null 2>&1; then
-  if timeout 30s npm run test:ci --workspace=@m68k/core; then
-    echo "@m68k/core tests completed"
-  else
+  if ! timeout 30s npm run test:ci --workspace=@m68k/memory; then
     rc=$?
     if [[ $rc -eq 124 ]]; then
-      echo "@m68k/core tests hit soft timeout (30s); treating as success to avoid hang"
+      echo "@m68k/memory tests timed out after 30s"
     else
-      echo "@m68k/core tests failed with exit code $rc"
-      exit $rc
+      echo "@m68k/memory tests failed with exit code $rc"
     fi
+    exit $rc
   fi
 else
-  npm run test:ci --workspace=@m68k/core || true
+  npm run test:ci --workspace=@m68k/memory
+fi
+
+# Run @m68k/core tests with a hard 30s timeout (fail on timeout)
+echo "Running @m68k/core tests (30s timeout)..."
+if command -v timeout >/dev/null 2>&1; then
+  timeout 30s npm run test:ci --workspace=@m68k/core
+else
+  npm run test:ci --workspace=@m68k/core
 fi
 
 echo "All tests completed"
-


### PR DESCRIPTION
- Add timeout-minutes to native/wasm CI test steps\n- Add run-tests-ci.sh and wire root test:ci\n- ForceExit and single worker for workspace Jest test:ci\n- Increase core Jest testTimeout to 10s\n\nThis PR only affects CI/test harnesses and does not change runtime behavior.