### PR TITLE
test(core): add System.cleanup() usage; types expose cleanup to prevent Jest hangs

### DIFF
--- a/packages/core/src/disassemble.test.ts
+++ b/packages/core/src/disassemble.test.ts
@@ -1,9 +1,16 @@
 import { createSystem } from './index';
 
 describe('disassembly helpers', () => {
+  let sys: any;
+
+  afterEach(() => {
+    if (sys && typeof sys.cleanup === 'function') sys.cleanup();
+    sys = undefined;
+  });
+
   it('disassembles a NOP at 0x400', async () => {
     const rom = new Uint8Array(0x2000);
-    const sys = await createSystem({ rom, ramSize: 0x10000 });
+    sys = await createSystem({ rom, ramSize: 0x10000 });
 
     // Place a NOP (0x4E71) at the reset PC (0x00000400)
     sys.write(0x400, 1, 0x4e);
@@ -15,7 +22,7 @@ describe('disassembly helpers', () => {
 
   it('disassembles a short sequence', async () => {
     const rom = new Uint8Array(0x2000);
-    const sys = await createSystem({ rom, ramSize: 0x10000 });
+    sys = await createSystem({ rom, ramSize: 0x10000 });
 
     // Sequence: NOP (0x4E71), RTS (0x4E75)
     sys.write(0x600, 1, 0x4e);
@@ -29,7 +36,7 @@ describe('disassembly helpers', () => {
 
   it('disassembles complex instructions and formats text lines', async () => {
     const rom = new Uint8Array(0x4000);
-    const sys = await createSystem({ rom, ramSize: 0x20000 });
+    sys = await createSystem({ rom, ramSize: 0x20000 });
 
     const cases: Array<{ addr: number; bytes: number[]; expect: string }> = [
       { addr: 0x0800, bytes: [0x73, 0x7f], expect: 'moveq   #$7f, D3' },

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -57,7 +57,8 @@ describe('@m68k/core', () => {
   });
 
   afterEach(() => {
-    // No cleanup method in System interface
+    // Clean up system resources to prevent Jest from hanging
+    system.cleanup();
   });
 
   it('should create a system', () => {

--- a/packages/core/src/instruction-size.test.ts
+++ b/packages/core/src/instruction-size.test.ts
@@ -1,9 +1,16 @@
 import { createSystem } from './index';
 
 describe('getInstructionSize', () => {
+  let sys: any;
+
+  afterEach(() => {
+    if (sys && typeof sys.cleanup === 'function') sys.cleanup();
+    sys = undefined;
+  });
+
   it('returns correct sizes for common instructions', async () => {
     const rom = new Uint8Array(0x4000);
-    const sys = await createSystem({ rom, ramSize: 0x20000 });
+    sys = await createSystem({ rom, ramSize: 0x20000 });
 
     // NOP at 0x0600 (0x4E71) -> 2 bytes
     sys.write(0x600, 1, 0x4e);
@@ -43,4 +50,3 @@ describe('getInstructionSize', () => {
     expect(sys.getInstructionSize(0xa00)).toBe(4);
   });
 });
-

--- a/packages/core/src/memtrace-absolute.test.ts
+++ b/packages/core/src/memtrace-absolute.test.ts
@@ -5,6 +5,13 @@ function hex(n: number) {
 }
 
 describe('Memory trace for absolute long accesses (read path)', () => {
+  let sys: any;
+
+  afterEach(() => {
+    if (sys && typeof sys.cleanup === 'function') sys.cleanup();
+    sys = undefined;
+  });
+
   it('emits read events with correct addr/size/value/pc for MOVE.L (abs).L', async () => {
     // Build a ROM large enough to place code at 0x416 and 0x41c
     const rom = new Uint8Array(0x200000);
@@ -16,7 +23,7 @@ describe('Memory trace for absolute long accesses (read path)', () => {
     rom.set([0x20, 0x79, 0x00, 0x10, 0x6e, 0x80], 0x416);
     rom.set([0x20, 0x39, 0x00, 0x10, 0x6e, 0x80], 0x41c);
 
-    const sys = await createSystem({ rom, ramSize: 0x100000 });
+    sys = await createSystem({ rom, ramSize: 0x100000 });
     sys.setRegister('sr', 0x2704);
     sys.setRegister('sp', 0x10f300);
     sys.setRegister('a0', 0x100a80);
@@ -64,4 +71,3 @@ describe('Memory trace for absolute long accesses (read path)', () => {
     }
   });
 });
-

--- a/packages/core/src/step-metadata-contract.test.ts
+++ b/packages/core/src/step-metadata-contract.test.ts
@@ -22,6 +22,10 @@ describe('step() metadata contract', () => {
     system = await createSystem({ rom, ramSize: 0x1000 });
   });
 
+  afterEach(() => {
+    system.cleanup();
+  });
+
   it('endPc equals startPc + getInstructionSize(startPc)', async () => {
     // Step 1
     let start = system.getRegisters().pc >>> 0;
@@ -48,4 +52,3 @@ describe('step() metadata contract', () => {
     expect(s3.endPc >>> 0).toBe((start + size) >>> 0);
   });
 });
-

--- a/packages/core/src/step.test.ts
+++ b/packages/core/src/step.test.ts
@@ -34,6 +34,10 @@ describe('@m68k/core step()', () => {
     system = await createSystem({ rom, ramSize: 0x1000 });
   });
 
+  afterEach(() => {
+    system.cleanup();
+  });
+
   it('executes exactly one instruction and advances PC', async () => {
     const regs0 = system.getRegisters();
     expect(regs0.pc >>> 0).toBe(0x400);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -186,4 +186,10 @@ export interface System {
    * Returns a function to unsubscribe.
    */
   onMemoryWrite(cb: MemoryAccessCallback): () => void;
+
+  /**
+   * Releases resources associated with the underlying WASM module/session.
+   * Should be called when the system is no longer needed to prevent leaks.
+   */
+  cleanup(): void;
 }


### PR DESCRIPTION
- Add cleanup() to System interface\n- Call cleanup() in afterEach in core tests to ensure WASM resources are released\n\nThis PR only adjusts types and tests; runtime behavior is unchanged.