### PR TITLE
test(core): fix disassembly expectations; relax PC checks for prefetch variance

### DIFF
--- a/packages/core/src/disassemble.test.ts
+++ b/packages/core/src/disassemble.test.ts
@@ -32,15 +32,18 @@ describe('disassembly helpers', () => {
     const sys = await createSystem({ rom, ramSize: 0x20000 });
 
     const cases: Array<{ addr: number; bytes: number[]; expect: string }> = [
-      { addr: 0x0800, bytes: [0x73, 0x7f], expect: 'moveq   #$7f, D3' },
+      // MOVEQ #$7f,D3 encoding: 0x767f (0111 ddd 0 iiiiiiii)
+      { addr: 0x0800, bytes: [0x76, 0x7f], expect: 'moveq   #$7f, D3' },
       { addr: 0x0810, bytes: [0x4e, 0x56, 0xff, 0xf8], expect: 'link    A6, #-$8' },
       { addr: 0x0820, bytes: [0x4e, 0x5e], expect: 'unlk    A6' },
       { addr: 0x0830, bytes: [0x41, 0xf9, 0x00, 0x12, 0x34, 0x56], expect: 'lea     $123456.l, A0' },
       { addr: 0x0840, bytes: [0x4e, 0x91], expect: 'jsr     (A1)' },
-      { addr: 0x0850, bytes: [0x61, 0x06], expect: 'bsr     $856' },
+      // BSR disp8 is relative to PC+2, so from 0x0850 with +6 -> 0x0858
+      { addr: 0x0850, bytes: [0x61, 0x06], expect: 'bsr     $858' },
       { addr: 0x0860, bytes: [0x06, 0x81, 0x00, 0x00, 0x00, 0x01], expect: 'addi.l  #$1, D1' },
       { addr: 0x0870, bytes: [0x48, 0x57], expect: 'pea     (A7)' },
-      { addr: 0x0880, bytes: [0x51, 0xc8, 0xff, 0xfe], expect: 'dbra    D0, $87e' },
+      // DBRA with disp16=-2 from 0x0880 branches to 0x0880
+      { addr: 0x0880, bytes: [0x51, 0xc8, 0xff, 0xfe], expect: 'dbra    D0, $880' },
     ];
 
     for (const tc of cases) {


### PR DESCRIPTION
- Correct MOVEQ/BSR/DBRA disassembly expectations\n- Allow minor PC variance due to prefetch across builds\n\nTest-only changes; no runtime behavior change.