### PR TITLE
feat(core): unified memory layout + mirroring (optional, backward compatible)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,7 +153,7 @@ class SystemImpl implements System {
     this.tracer = new TracerImpl(musashi);
 
     // Initialize Musashi with memory regions and hooks
-    this._musashi.init(this, config.rom, this.ram);
+    this._musashi.init(this, config.rom, this.ram, config.memoryLayout);
   }
 
   // (no fusion-specific instrumentation helpers)

--- a/packages/core/src/memory-layout.test.ts
+++ b/packages/core/src/memory-layout.test.ts
@@ -1,0 +1,93 @@
+import { createSystem } from './index.js';
+import type { MemoryLayout, System } from './types.js';
+
+function makeRom(size: number): Uint8Array {
+  const rom = new Uint8Array(size);
+  for (let i = 0; i < size; i++) rom[i] = i & 0xff;
+  // Ensure reset vectors exist; wrapper overwrites, but keep sane ROM
+  rom[0] = 0x00; rom[1] = 0x10; rom[2] = 0x80; rom[3] = 0x00; // SSP
+  rom[4] = 0x00; rom[5] = 0x00; rom[6] = 0x04; rom[7] = 0x00; // PC
+  return rom;
+}
+
+describe('Unified memory layout (regions + mirrors)', () => {
+  let system: System;
+
+  afterEach(() => {
+    // Clean up system resources to prevent Jest from hanging
+    if (system) {
+      system.cleanup();
+    }
+  });
+
+  it('maps regions, applies mirrors, ensures capacity, and reflects RAM writes', async () => {
+    const rom = makeRom(0x300000);
+    const ramSize = 0x12000; // must cover sourceOffset + length for RAM region
+
+    const layout: MemoryLayout = {
+      regions: [
+        // Map 0x1000 bytes of ROM at 0x080000 from ROM offset 0x10000
+        { start: 0x080000, length: 0x1000, source: 'rom', sourceOffset: 0x10000 },
+        // Map 0x8000 bytes of ROM at 0x200000 from ROM offset 0x18000
+        { start: 0x200000, length: 0x8000, source: 'rom', sourceOffset: 0x18000 },
+        // Map 0x10000 bytes of RAM at 0x300000 from RAM offset 0x2000 (fits within 0x12000 RAM)
+        { start: 0x300000, length: 0x10000, source: 'ram', sourceOffset: 0x2000 },
+      ],
+      mirrors: [
+        // Mirror the 0x8000 window from 0x200000 to 0x210000
+        { start: 0x210000, length: 0x8000, mirrorFrom: 0x200000 },
+      ],
+      minimumCapacity: 0x400000,
+    };
+
+    system = await createSystem({ rom, ramSize, memoryLayout: layout });
+
+    // Region 1 checks
+    const r1Start = 0x080000;
+    const r1Off = 0x10000;
+    expect(system.read(r1Start, 1) & 0xff).toBe(rom[r1Off]);
+    expect(system.read(r1Start + 0x0fff, 1) & 0xff).toBe(rom[r1Off + 0x0fff]);
+
+    // Region 2 checks
+    const r2Start = 0x200000;
+    const r2Off = 0x18000;
+    expect(system.read(r2Start, 1) & 0xff).toBe(rom[r2Off]);
+    expect(system.read(r2Start + 0x7fff, 1) & 0xff).toBe(rom[r2Off + 0x7fff]);
+
+    // Mirror checks: 0x210000 mirrors 0x200000
+    const mirStart = 0x210000;
+    expect(system.read(mirStart, 1) & 0xff).toBe(rom[r2Off]);
+    expect(system.read(mirStart + 0x1234, 1) & 0xff).toBe(rom[r2Off + 0x1234]);
+    // Capacity: highest covered address is within readable range
+    expect(system.read(mirStart + 0x7fff, 1) & 0xff).toBe(rom[r2Off + 0x7fff]);
+
+    // RAM reflection: region at 0x300000 from RAM offset 0x2000
+    const ramStart = 0x300000;
+    const ramOff = 0x2000;
+    // Initially zeroed
+    expect(system.read(ramStart, 1)).toBe(0);
+    // Byte write
+    system.write(ramStart + 0x10, 1, 0xab);
+    expect(system.read(ramStart + 0x10, 1) & 0xff).toBe(0xab);
+    expect(system.readBytes(ramStart + 0x10, 1)[0]).toBe(0xab);
+    expect((system as any).ram[ramOff + 0x10]).toBe(0xab);
+    // 32-bit write (big-endian)
+    system.write(ramStart + 0x20, 4, 0x11223344);
+    expect((system as any).ram[ramOff + 0x20]).toBe(0x11);
+    expect((system as any).ram[ramOff + 0x21]).toBe(0x22);
+    expect((system as any).ram[ramOff + 0x22]).toBe(0x33);
+    expect((system as any).ram[ramOff + 0x23]).toBe(0x44);
+  });
+
+  it('preserves backward-compatible defaults when memoryLayout is omitted', async () => {
+    const rom = makeRom(0x200000);
+    system = await createSystem({ rom, ramSize: 0x2000 });
+
+    // ROM at 0x000000, RAM at 0x100000 by default
+    expect(system.read(0x000004, 1) & 0xff).toBe(rom[4]);
+    // Writes to 0x100000 reflect into RAM at offset 0
+    system.write(0x100000, 1, 0x5a);
+    expect((system as any).ram[0]).toBe(0x5a);
+  });
+});
+

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -4,6 +4,7 @@
 type EmscriptenBuffer = number;
 type EmscriptenFunction = number;
 import { M68kRegister } from '@m68k/common';
+import type { MemoryLayout } from './types.js';
 
 export interface MusashiEmscriptenModule {
   _my_initialize(): boolean;
@@ -91,7 +92,8 @@ interface SystemBridge {
 export class MusashiWrapper {
   private _module: MusashiEmscriptenModule;
   private _system!: SystemBridge; // Reference to SystemImpl
-  private _memory: Uint8Array = new Uint8Array(2 * 1024 * 1024); // 2MB memory
+  private _memory: Uint8Array = new Uint8Array(0); // allocated in init()
+  private _ramWindows: Array<{ start: number; length: number; offset: number }> = [];
   private _readFunc: EmscriptenFunction = 0;
   private _writeFunc: EmscriptenFunction = 0;
   private _probeFunc: EmscriptenFunction = 0;
@@ -105,8 +107,83 @@ export class MusashiWrapper {
     this._module = module;
   }
 
-  init(system: SystemBridge, rom: Uint8Array, ram: Uint8Array) {
+  init(system: SystemBridge, rom: Uint8Array, ram: Uint8Array, memoryLayout?: MemoryLayout) {
     this._system = system;
+
+    // --- Allocate unified memory based on layout or defaults ---
+    const DEFAULT_CAPACITY = 2 * 1024 * 1024; // 2MB
+    let capacity = DEFAULT_CAPACITY >>> 0;
+    this._ramWindows = [];
+
+    if (memoryLayout && ((memoryLayout.regions && memoryLayout.regions.length) || (memoryLayout.mirrors && memoryLayout.mirrors.length))) {
+      let maxEnd = 0;
+      for (const r of memoryLayout.regions ?? []) {
+        const start = r.start >>> 0;
+        const length = r.length >>> 0;
+        if (length === 0) continue;
+        const end = (start + length) >>> 0;
+        if (end > maxEnd) maxEnd = end;
+      }
+      for (const m of memoryLayout.mirrors ?? []) {
+        const destStart = m.start >>> 0;
+        const destEnd = (destStart + (m.length >>> 0)) >>> 0;
+        if (destEnd > maxEnd) maxEnd = destEnd;
+        const srcStart = m.mirrorFrom >>> 0;
+        const srcEnd = (srcStart + (m.length >>> 0)) >>> 0;
+        if (srcEnd > maxEnd) maxEnd = srcEnd;
+      }
+      const minCap = (memoryLayout.minimumCapacity ?? 0) >>> 0;
+      capacity = Math.max(maxEnd, minCap, 0) >>> 0;
+    }
+
+    this._memory = new Uint8Array(capacity);
+
+    // --- Initialize regions ---
+    if (memoryLayout && ((memoryLayout.regions && memoryLayout.regions.length) || (memoryLayout.mirrors && memoryLayout.mirrors.length))) {
+      // Base regions
+      for (const r of memoryLayout.regions ?? []) {
+        const start = r.start >>> 0;
+        const length = r.length >>> 0;
+        const srcOff = (r.sourceOffset ?? 0) >>> 0;
+        if (length === 0) continue;
+        // Bounds validation
+        if (start + length > this._memory.length) {
+          throw new Error(`Region out of bounds: start=0x${start.toString(16)}, len=0x${length.toString(16)}, cap=0x${this._memory.length.toString(16)}`);
+        }
+        if (r.source === 'rom') {
+          if (srcOff + length > rom.length) {
+            throw new Error(`ROM source out of range: off=0x${srcOff.toString(16)}, len=0x${length.toString(16)}, rom=0x${rom.length.toString(16)}`);
+          }
+          this._memory.set(rom.subarray(srcOff, srcOff + length), start);
+        } else if (r.source === 'ram') {
+          if (srcOff + length > ram.length) {
+            throw new Error(`RAM source out of range: off=0x${srcOff.toString(16)}, len=0x${length.toString(16)}, ram=0x${ram.length.toString(16)}`);
+          }
+          this._memory.set(ram.subarray(srcOff, srcOff + length), start);
+          // Record window for write-back to RAM buffer
+          this._ramWindows.push({ start, length, offset: srcOff });
+        } else if (r.source === 'zero') {
+          this._memory.fill(0, start, start + length);
+        }
+      }
+      // Mirrors
+      for (const m of memoryLayout.mirrors ?? []) {
+        const start = m.start >>> 0;
+        const length = m.length >>> 0;
+        const from = m.mirrorFrom >>> 0;
+        if (length === 0) continue;
+        if (from + length > this._memory.length || start + length > this._memory.length) {
+          throw new Error(`Mirror out of bounds: from=0x${from.toString(16)}, start=0x${start.toString(16)}, len=0x${length.toString(16)}, cap=0x${this._memory.length.toString(16)}`);
+        }
+        const src = this._memory.subarray(from, from + length);
+        this._memory.set(src, start);
+      }
+    } else {
+      // Backward-compatible default mapping
+      this._memory.set(rom, 0x000000);
+      this._memory.set(ram, 0x100000);
+      this._ramWindows.push({ start: 0x100000, length: ram.length >>> 0, offset: 0 });
+    }
 
     // Setup callbacks FIRST (critical for expert's fix)
     this._readFunc = this._module.addFunction((addr: number) => {
@@ -265,6 +342,13 @@ export class MusashiWrapper {
     // Read from our unified memory (big-endian composition)
     if (address >= this._memory.length) return 0;
     if (address + size > this._memory.length) return 0;
+    // If the access starts in a RAM window, ensure it does not cross that window's end
+    for (const w of this._ramWindows) {
+      if (address >= w.start && address < (w.start + w.length)) {
+        if (address + size > (w.start + w.length)) return 0;
+        break;
+      }
+    }
 
     if (size === 1) {
       return this._memory[address];
@@ -281,36 +365,42 @@ export class MusashiWrapper {
   }
 
   write_memory(address: number, size: 1 | 2 | 4, value: number) {
-    // Write to our unified memory (big-endian decomposition)
-    if (address >= this._memory.length) return;
-    if (address + size > this._memory.length) return;
-
+    const addr = address >>> 0;
+    // Respect bounds strictly: ignore cross-boundary writes
+    if (addr >= this._memory.length) return;
+    if (addr + size > this._memory.length) return;
+    // If the write starts in a RAM window, ensure it does not cross that window's end
+    for (const w of this._ramWindows) {
+      if (addr >= w.start && addr < (w.start + w.length)) {
+        if (addr + size > (w.start + w.length)) return;
+        break;
+      }
+    }
+    const bytes: number[] = [];
     if (size === 1) {
-      this._memory[address] = value & 0xff;
+      bytes.push(value & 0xff);
     } else if (size === 2) {
-      this._memory[address] = (value >> 8) & 0xff;
-      this._memory[address + 1] = value & 0xff;
+      bytes.push((value >> 8) & 0xff, value & 0xff);
     } else {
-      this._memory[address] = (value >> 24) & 0xff;
-      this._memory[address + 1] = (value >> 16) & 0xff;
-      this._memory[address + 2] = (value >> 8) & 0xff;
-      this._memory[address + 3] = value & 0xff;
+      bytes.push(
+        (value >> 24) & 0xff,
+        (value >> 16) & 0xff,
+        (value >> 8) & 0xff,
+        value & 0xff
+      );
     }
 
-    // Update the JS-side RAM copy if this is in RAM space
-    const ramStart = 0x100000;
-    if (address >= ramStart && address < ramStart + this._system.ram.length) {
-      const offset = address - ramStart;
-      if (size === 1) {
-        this._system.ram[offset] = value & 0xff;
-      } else if (size === 2) {
-        this._system.ram[offset] = (value >> 8) & 0xff;
-        this._system.ram[offset + 1] = value & 0xff;
-      } else {
-        this._system.ram[offset] = (value >> 24) & 0xff;
-        this._system.ram[offset + 1] = (value >> 16) & 0xff;
-        this._system.ram[offset + 2] = (value >> 8) & 0xff;
-        this._system.ram[offset + 3] = value & 0xff;
+    for (let i = 0; i < bytes.length; i++) {
+      const a = (addr + i) >>> 0;
+      this._memory[a] = bytes[i] & 0xff;
+      // Reflect into RAM windows
+      for (const w of this._ramWindows) {
+        if (a >= w.start && a < (w.start + w.length)) {
+          const ramIndex = (w.offset + (a - w.start)) >>> 0;
+          if (ramIndex < this._system.ram.length) {
+            this._system.ram[ramIndex] = bytes[i] & 0xff;
+          }
+        }
       }
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,8 @@ export interface SystemConfig {
   rom: Uint8Array;
   /** The size of the system's RAM in bytes. */
   ramSize: number;
+  /** Optional memory layout describing regions and mirrors. */
+  memoryLayout?: MemoryLayout;
 }
 
 /** Configuration for a Perfetto tracing session. */
@@ -60,6 +62,40 @@ export interface TraceConfig {
 
 /** A map of memory addresses to human-readable names. */
 export type SymbolMap = Record<number, string>;
+
+// --- Unified Memory Layout Types ---
+
+/** Describes a directly populated region in unified memory. */
+export type MemoryRegion = {
+  /** Absolute start address of the region in unified memory. */
+  start: number;
+  /** Length of the region in bytes. */
+  length: number;
+  /** Source of initial bytes. */
+  source: 'rom' | 'ram' | 'zero';
+  /** Optional byte offset within the source array. Defaults to 0. */
+  sourceOffset?: number;
+};
+
+/** Describes a mirrored region copied from an already initialized span. */
+export type MirrorRegion = {
+  /** Destination start address of the mirror. */
+  start: number;
+  /** Length of the mirror region in bytes. */
+  length: number;
+  /** Source start address within unified memory (must be initialized). */
+  mirrorFrom: number;
+};
+
+/** Optional memory layout configuration for unified memory and mirrors. */
+export type MemoryLayout = {
+  /** Direct regions copied from ROM/RAM/zero. */
+  regions?: MemoryRegion[];
+  /** Mirrors that duplicate an initialized span into another address range. */
+  mirrors?: MirrorRegion[];
+  /** Optional minimum capacity for the unified memory buffer. */
+  minimumCapacity?: number;
+};
 
 /**
  * Interface for controlling and capturing Perfetto performance traces.


### PR DESCRIPTION
- Add MemoryLayout types and optional SystemConfig.memoryLayout\n- Allocate unified memory based on configured regions + mirrors\n- Mirror regions after base population; last-writer wins\n- Track RAM windows so writes reflect into backing RAM regardless of mapping\n- Preserve default mapping (ROM@0x0, RAM@0x100000) when memoryLayout omitted\n- Add tests covering mapping, mirroring, capacity, and defaults