### PR TITLE
compat: drop legacy WASM shims; use size-aware callbacks; complete m68k_perfetto_* migration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,15 +88,6 @@ exported_functions=(
   _m68k_trace_set_instr_enabled
   _m68k_trace_set_mem_enabled
   _my_initialize
-  _perfetto_destroy
-  _perfetto_enable_flow
-  _perfetto_enable_instructions
-  _perfetto_enable_memory
-  _perfetto_export_trace
-  _perfetto_free_trace_data
-  _perfetto_init
-  _perfetto_is_initialized
-  _perfetto_save_trace
   _register_function_name
   _register_memory_name
   _register_memory_range
@@ -104,10 +95,7 @@ exported_functions=(
   _set_entry_point
   _set_full_instr_hook_func
   _set_pc_hook_func
-  _set_probe_callback
-  _set_read8_callback
   _set_read_mem_func
-  _set_write8_callback
   _set_write_mem_func
 )
 
@@ -129,13 +117,13 @@ fi
 
 # Runtime function includes (need $-prefixed names)
 default_lib_funcs=(
-  '$addFunction' '$removeFunction' '$ccall' '$cwrap' '$getValue'
+  '$addFunction' '$removeFunction' '$getValue'
   '$setValue' '$UTF8ToString' '$stringToUTF8' '$writeArrayToMemory'
 )
 
 runtime_methods=(
   HEAP8 HEAPU8 HEAP16 HEAPU16 HEAP32 HEAPU32 HEAPF32 HEAPF64
-  addFunction removeFunction ccall cwrap getValue setValue UTF8ToString
+  addFunction removeFunction getValue setValue UTF8ToString
   stringToUTF8 writeArrayToMemory
 )
 

--- a/tests/test_perfetto.cpp
+++ b/tests/test_perfetto.cpp
@@ -184,7 +184,7 @@ TEST_F(PerfettoTest, FlowTracing) {
     
     #ifdef ENABLE_PERFETTO
         /* Verify we can save the trace */
-        int save_result = ::perfetto_save_trace("test_flow.perfetto-trace");
+        int save_result = ::m68k_perfetto_save_trace("test_flow.perfetto-trace");
         EXPECT_EQ(save_result, 0);
     #endif
 }
@@ -245,17 +245,17 @@ TEST_F(PerfettoTest, BranchAndSubroutineTracing) {
     
     #ifdef ENABLE_PERFETTO
         /* Save trace for inspection */
-        ::perfetto_save_trace("test_branch_subroutine.perfetto-trace");
+        ::m68k_perfetto_save_trace("test_branch_subroutine.perfetto-trace");
     #endif
 }
 
 TEST_F(PerfettoTest, MemoryAccessTracing) {
-    if (::perfetto_init("M68K_Memory_Test") != 0) {
+    if (::m68k_perfetto_init("M68K_Memory_Test") != 0) {
         GTEST_SKIP() << "Perfetto not available, skipping memory tracing test";
     }
     
     /* Enable memory tracing */
-    ::perfetto_enable_memory(1);
+    ::m68k_perfetto_enable_memory(1);
     
     /* Create program that accesses memory */
     uint32_t pc = 0x400;
@@ -284,7 +284,7 @@ TEST_F(PerfettoTest, MemoryAccessTracing) {
     
     #ifdef ENABLE_PERFETTO
         /* Save trace */
-        ::perfetto_save_trace("test_memory_access.perfetto-trace");
+        ::m68k_perfetto_save_trace("test_memory_access.perfetto-trace");
     #endif
 }
 
@@ -313,9 +313,9 @@ TEST_F(PerfettoTest, ManuallyEncodedProgram) {
     }
     
     /* Initialize Perfetto if available */
-    if (::perfetto_init("M68K_Manual_Program") == 0) {
-        ::perfetto_enable_flow(1);
-        ::perfetto_enable_instructions(1);
+    if (::m68k_perfetto_init("M68K_Manual_Program") == 0) {
+        ::m68k_perfetto_enable_flow(1);
+        ::m68k_perfetto_enable_instructions(1);
     }
     
     /* Execute the program */
@@ -333,8 +333,8 @@ TEST_F(PerfettoTest, ManuallyEncodedProgram) {
     
     #ifdef ENABLE_PERFETTO
         /* Save trace if Perfetto was initialized */
-        if (::perfetto_is_initialized()) {
-            ::perfetto_save_trace("test_manual_program.perfetto-trace");
+        if (::m68k_perfetto_is_initialized()) {
+            ::m68k_perfetto_save_trace("test_manual_program.perfetto-trace");
         }
     #endif
 }

--- a/tests/test_vasm_binary.cpp
+++ b/tests/test_vasm_binary.cpp
@@ -49,10 +49,10 @@ TEST_F(VasmBinaryTest, ExecuteBinaryWithPerfettoTrace) {
     m68k_trace_enable(1);
     
     /* Initialize Perfetto */
-    if (perfetto_init("VasmBinary") == 0) {
-        perfetto_enable_flow(1);
-        perfetto_enable_memory(0);      /* Disable memory tracing for cleaner output */
-        perfetto_enable_instructions(0); /* Disable instruction tracing */
+    if (m68k_perfetto_init("VasmBinary") == 0) {
+        m68k_perfetto_enable_flow(1);
+        m68k_perfetto_enable_memory(0);      /* Disable memory tracing for cleaner output */
+        m68k_perfetto_enable_instructions(0); /* Disable instruction tracing */
     }
     
     /* Execute the program */
@@ -115,9 +115,9 @@ TEST_F(VasmBinaryTest, ExecuteBinaryWithPerfettoTrace) {
     EXPECT_TRUE(memory_modified) << "Program should write results to memory";
     
     /* Save Perfetto trace if initialized */
-    if (perfetto_is_initialized()) {
-        perfetto_save_trace("vasm_binary_trace.perfetto-trace");
-        perfetto_destroy();
+    if (m68k_perfetto_is_initialized()) {
+        m68k_perfetto_save_trace("vasm_binary_trace.perfetto-trace");
+        m68k_perfetto_destroy();
     }
 }
 


### PR DESCRIPTION
Follow-up to #65 (rebased and slimmed). This PR keeps only the non-obsoleted changes after recent master merges:\n\n- build.sh: remove legacy exports () and / runtime methods\n- core wrapper: switch to / and clear probe via  in cleanup\n- native C++ tests: complete migration to  APIs\n\nAll CI/test timeboxing and ESM/test harness updates from #65 were superseded by #73–#78 and are excluded here.\n\nCloses #65 once merged (supersedes it).