### PR TITLE
feat(core): add unified hook + detailed disassembly + dispose() (non-breaking)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -29,6 +29,9 @@ export interface CpuRegisters {
 /** A function to be executed when a specific address is hit during execution. */
 export type HookCallback = (system: System) => void;
 
+/** Unified hook result indicating how execution should proceed. */
+export type HookResult = 'continue' | 'stop';
+
 /** Memory access event payload for JS callbacks. */
 export interface MemoryAccessEvent {
   addr: number;
@@ -197,6 +200,12 @@ export interface System {
    */
   override(address: number, callback: HookCallback): () => void;
 
+  /**
+   * Adds a unified PC hook. The handler returns whether to continue or stop.
+   * This is an additive API; legacy probe/override remain available.
+   */
+  addHook(address: number, handler: (system: System) => HookResult): () => void;
+
   /** Accesses the optional Perfetto tracing functionality. */
   readonly tracer: Tracer;
 
@@ -208,6 +217,9 @@ export interface System {
    * Returns 0 if the disassembler is unavailable or decoding fails.
    */
   getInstructionSize(pc: number): number;
+
+  /** Detailed disassembly including size, when available. */
+  disassembleDetailed(address: number): { text: string; size: number } | null;
 
   /**
    * Register a callback for memory reads performed by the CPU. The callback receives
@@ -228,4 +240,7 @@ export interface System {
    * Should be called when the system is no longer needed to prevent leaks.
    */
   cleanup(): void;
+
+  /** Alias for cleanup(). */
+  dispose(): void;
 }


### PR DESCRIPTION
Follow-up to #54, rebased and reduced to additive changes:\n\n- Add System.addHook(addr, handler) returning 'continue' | 'stop' (keeps legacy probe/override)\n- Add System.disassembleDetailed(pc) returning { text, size } (retains text-only disassemble and getInstructionSize)\n- Add System.dispose() as alias to cleanup()\n- Export HookResult type\n\nExcluded as obsolete/breaking from #54:\n- Removing probe/override and getInstructionSize (would be breaking)\n- npm-package enum edits (current lib re-exports from @m68k/common and no longer defines numeric values)\n- Test rewrites to the new API (not required for additive change)\n\nThis lands the useful parts of #54 without breaking existing consumers.\n