### PR TITLE
Fix @m68k/common dist ESM

### DIFF
--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
@@ -8,4 +10,3 @@
   },
   "include": ["src/**/*"]
 }
-


### PR DESCRIPTION
## Summary
- set compilerOptions.module to ES2020 and moduleResolution to bundler so the dist is true ESM
- fixes native Node ESM import of @m68k/core/dist/index.js

## Testing
- npm run build
- node --input-type=module -e "import { createSystem } from './packages/core/dist/index.js'; console.log(typeof createSystem)"
