### PR TITLE
Release 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2025-09-16
+
+### 🐛 Bug Fixes
+
+- **Node import compatibility**: Ensure `@m68k/common` emits ES modules so `@m68k/core`'s dist bundle loads under native Node ESM environments without missing export errors.
+
 ## [0.1.3] - 2025-08-17
 
 ### 🐛 Bug Fixes

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump musashi-wasm npm package to 0.1.7
- document the Node import compatibility fix in the changelog

## Testing
- npm run build
- (npm-package) npm run build
