### PR TITLE
Fix unsigned 32-bit memory reads

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -90,6 +90,15 @@ describe('@m68k/core', () => {
     expect(system.read(ramBase + 6, 2)).toBe(0xcdef);
   });
 
+  it('handles unsigned 32-bit values correctly', () => {
+    const ramBase = 0x100000;
+    const value = 0xf2345678;
+
+    system.write(ramBase, 4, value);
+    const readBack = system.read(ramBase, 4);
+    expect(readBack).toBe(value >>> 0);
+  });
+
   it('respects memory bounds for multi-byte access', () => {
     const ramBase = 0x100000;
     const ramSize = 0x1000;

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -294,7 +294,7 @@ export class MusashiWrapper {
         (this._memory[address + 1] << 16) |
         (this._memory[address + 2] << 8) |
         this._memory[address + 3]
-      );
+      ) >>> 0;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure 32-bit memory reads return unsigned values
- add regression test for high-bit 32-bit memory reads

## Testing
- `npm test` *(fails: Cannot find module './musashi-node.out.mjs')*
- `npm run typecheck` *(fails: Cannot find module '@m68k/core')*
- `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure` *(fails: gmake[3]: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2237246588331a11ad459a4a818c4