### PR TITLE
Make tracer.stop synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ if (system.tracer.isAvailable()) {
   system.run(100000);
 
   // Export trace
-  const traceData = await system.tracer.stop();
+  const traceData = system.tracer.stop();
   fs.writeFileSync('trace.perfetto-trace', traceData);
 }
 ```

--- a/packages/README.md
+++ b/packages/README.md
@@ -89,7 +89,7 @@ if (system.tracer.isAvailable()) {
   system.run(100000);
 
   // Stop and export trace
-  const traceData = await system.tracer.stop();
+  const traceData = system.tracer.stop();
   
   // Save to file (Node.js)
   fs.writeFileSync('trace.perfetto-trace', traceData);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,7 +86,7 @@ class TracerImpl implements Tracer {
     this._active = true;
   }
 
-  async stop(): Promise<Uint8Array> {
+  stop(): Uint8Array {
     if (!this._active) {
       throw new Error('No active tracing session to stop.');
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -120,7 +120,7 @@ export interface Tracer {
    * Throws an error if no session is active.
    * @returns A promise that resolves to the trace data as a `Uint8Array`.
    */
-  stop(): Promise<Uint8Array>;
+    stop(): Uint8Array;
 
   /**
    * Registers a map of addresses to function names. These names will appear

--- a/packages/example.ts
+++ b/packages/example.ts
@@ -165,7 +165,7 @@ async function main() {
   if (system.tracer.isAvailable() && traceData === null) {
     try {
       console.log('\nStopping trace...');
-      traceData = await system.tracer.stop();
+      traceData = system.tracer.stop();
       
       const traceFile = path.join(__dirname, 'example.perfetto-trace');
       fs.writeFileSync(traceFile, traceData);


### PR DESCRIPTION
## Summary
- make tracer.stop return trace data synchronously
- update docs/examples to match

## Testing
- timeout 60 npm test --workspace=@m68k/core