### PR TITLE
Release 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- Correct `System.step()` to keep the post-instruction PC reported by Musashi so control-flow opcodes (e.g., `jsr`) advance into their callees without losing stacked return writes.
+
+### ✅ Tests
+
+- Add a movem + `jsr` regression that asserts the stack delta and callee entry produced by the stepper.
+
 ## [0.1.8] - 2025-09-19
 
 ### 🚀 Improvements

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [
@@ -54,6 +54,6 @@
   },
   "dependencies": {
     "@m68k/common": "^0.1.0",
-    "@m68k/core": "^1.0.0"
+    "@m68k/core": "^1.0.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5107,7 +5107,7 @@
     },
     "packages/core": {
       "name": "@m68k/core",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@m68k/common": "^0.1.0"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@m68k/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "M68k CPU emulator core with WebAssembly backend",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,7 +222,7 @@ class SystemImpl implements System {
     let totalCycles = 0;
     let currentStartPc = startPc;
     let previousSp = initialSp;
-    let endPc = startPc;
+    let finalPc = startPc;
     let ppc = this._musashi.get_reg(M68kRegister.PPC) >>> 0;
 
     for (let iteration = 0; iteration < 2; iteration++) {
@@ -232,9 +232,8 @@ class SystemImpl implements System {
       totalCycles += Number(cyclesRaw) >>> 0;
 
       const afterPc = this._musashi.get_reg(M68kRegister.PC) >>> 0;
+      finalPc = afterPc;
       ppc = this._musashi.get_reg(M68kRegister.PPC) >>> 0;
-      const size = this.getInstructionSize(currentStartPc) >>> 0;
-      endPc = size > 0 ? ((currentStartPc + size) >>> 0) : afterPc;
 
       const spNow = this._musashi.get_reg(M68kRegister.A7) >>> 0;
       const spDelta = previousSp >= spNow ? (previousSp - spNow) >>> 0 : 0;
@@ -265,9 +264,9 @@ class SystemImpl implements System {
 
     // Normalize core state so subsequent reads see the final instruction boundary.
     this._musashi.set_reg(M68kRegister.PPC, currentStartPc >>> 0);
-    this._musashi.set_reg(M68kRegister.PC, endPc >>> 0);
+    this._musashi.set_reg(M68kRegister.PC, finalPc >>> 0);
 
-    return { cycles: totalCycles >>> 0, startPc, endPc, ppc };
+    return { cycles: totalCycles >>> 0, startPc, endPc: finalPc >>> 0, ppc };
   }
 
   reset(): void {

--- a/packages/core/src/step-jsr.test.ts
+++ b/packages/core/src/step-jsr.test.ts
@@ -1,0 +1,76 @@
+import { createSystem } from './index.js';
+
+describe('@m68k/core step() control flow', () => {
+  const STACK_BASE = 0x0010f300;
+  const ENTRY_PC = 0x0400;
+  const JSR_PC = 0x0404;
+  const RETURN_PC = 0x040a;
+  const TARGET_PC = 0x05dc1c;
+
+  const writeBytes = (buffer: Uint8Array, addr: number, bytes: number[]) => {
+    buffer.set(bytes, addr);
+  };
+
+  it('enters the jsr target and records the return address on stack', async () => {
+    const rom = new Uint8Array(0x200000);
+    const ramSize = 0x100000;
+
+    // Reset vectors
+    writeBytes(rom, 0, [
+      (STACK_BASE >>> 24) & 0xff,
+      (STACK_BASE >>> 16) & 0xff,
+      (STACK_BASE >>> 8) & 0xff,
+      STACK_BASE & 0xff
+    ]);
+    writeBytes(rom, 4, [0x00, 0x00, 0x04, 0x00]); // entry PC
+
+    // movem.l D0-D7/A0-A6, -(A7)
+    writeBytes(rom, ENTRY_PC, [0x48, 0xe7, 0xff, 0xfe]);
+    // jsr $05dc1c.l
+    writeBytes(rom, JSR_PC, [0x4e, 0xb9, 0x00, 0x05, 0xdc, 0x1c]);
+    // return trampoline: rts
+    writeBytes(rom, RETURN_PC, [0x4e, 0x75]);
+
+    // Callee body
+    writeBytes(rom, TARGET_PC, [0x30, 0x3c, 0x00, 0x9c]);
+    writeBytes(rom, TARGET_PC + 4, [0x21, 0xbc, 0xff, 0xff, 0xff, 0xff]);
+    writeBytes(rom, TARGET_PC + 10, [0x4e, 0x75]);
+
+    const system = await createSystem({ rom, ramSize });
+    try {
+      system.reset();
+      system.setRegister('sp', STACK_BASE);
+      system.setRegister('a0', 0x00100a80);
+      system.setRegister('d0', 0x009c);
+      system.setRegister('sr', 0x2704);
+
+      const step1 = system.step();
+      expect(step1.startPc >>> 0).toBe(ENTRY_PC);
+      expect(step1.endPc >>> 0).toBe(JSR_PC);
+
+      const step2 = system.step();
+      const regsAfterCall = system.getRegisters();
+
+      expect(step2.startPc >>> 0).toBe(JSR_PC);
+      expect(step2.endPc >>> 0).toBe(TARGET_PC);
+      expect(regsAfterCall.pc >>> 0).toBe(TARGET_PC);
+
+      const expectedSp = STACK_BASE - (15 * 4) - 4; // MOVEM saves 15 longs, JSR pushes return
+      expect(regsAfterCall.sp >>> 0).toBe(expectedSp);
+
+      const stackBytes = Array.from(
+        system.readBytes(expectedSp >>> 0, 4),
+        (b) => b & 0xff
+      );
+      expect(stackBytes).toEqual([0x00, 0x00, 0x04, 0x0a]);
+
+      const step3 = system.step();
+      expect(step3.startPc >>> 0).toBe(TARGET_PC);
+      expect(regsAfterCall.pc >>> 0).toBe(TARGET_PC);
+      const regsAfterStep3 = system.getRegisters();
+      expect(regsAfterStep3.pc >>> 0).toBe(TARGET_PC + 4);
+    } finally {
+      system.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- bump musashi-wasm to 0.1.9 and align @m68k/core at 1.0.2
- note the control-flow stepper fix in the changelog for this release
- regenerate package metadata ahead of publishing

## Testing
- env timeout 60 npm run test --workspace=@m68k/core
- npm run build --workspace=@m68k/core
- npm run build (npm-package)
