### PR TITLE
Avoid overwriting custom memory layouts during init

### DIFF
--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -107,6 +107,12 @@ export class MusashiWrapper {
     this._module = module;
   }
 
+  private applyDefaultMemoryMapping(rom: Uint8Array, ram: Uint8Array): void {
+    this._memory.set(rom, 0x000000);
+    this._memory.set(ram, 0x100000);
+    this._ramWindows.push({ start: 0x100000, length: ram.length >>> 0, offset: 0 });
+  }
+
   private getActiveMemoryLayout(memoryLayout?: MemoryLayout): MemoryLayout | undefined {
     if (!memoryLayout) {
       return undefined;
@@ -193,9 +199,7 @@ export class MusashiWrapper {
       }
     } else {
       // Backward-compatible default mapping
-      this._memory.set(rom, 0x000000);
-      this._memory.set(ram, 0x100000);
-      this._ramWindows.push({ start: 0x100000, length: ram.length >>> 0, offset: 0 });
+      this.applyDefaultMemoryMapping(rom, ram);
     }
 
     // Setup callbacks (size-aware read/write; PC hook)
@@ -213,10 +217,6 @@ export class MusashiWrapper {
     this._module._set_read_mem_func(readSizedPtr);
     this._module._set_write_mem_func(writeSizedPtr);
     this._module._set_pc_hook_func(this._probeFunc);
-
-    // Copy ROM and RAM into our memory
-    this._memory.set(rom, 0x000000);
-    this._memory.set(ram, 0x100000);
 
     // CRITICAL: Write reset vectors BEFORE init/reset
     this.write32BE(0x00000000, 0x00108000); // Initial SSP (in RAM)


### PR DESCRIPTION
## Summary
- extract a helper to apply the legacy ROM/RAM layout once
- stop reapplying the default mapping after callbacks are registered so custom layouts remain intact

## Testing
- timeout 60 npm run build --workspace=@m68k/common
- timeout 60 npm test --workspace=@m68k/core *(fails: requires musashi-node.out.mjs generated by the WASM build)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd88e3fe48331b0adf4bc4386b522