### PR TITLE
Prevent stale override removers from clearing active hook

### DIFF
--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -208,6 +208,29 @@ describe('@m68k/core', () => {
     removeOverride();
   });
 
+  it('removing a stale override does not clear the active override', () => {
+    const overrideAddress = 0x408;
+    const staleCalls: number[] = [];
+    const removeStale = system.override(overrideAddress, sys => {
+      staleCalls.push(sys.getRegisters().pc);
+    });
+
+    const activeCalls: number[] = [];
+    const removeActive = system.override(overrideAddress, sys => {
+      activeCalls.push(sys.getRegisters().pc);
+      sys.setRegister('pc', 0x40e);
+    });
+
+    removeStale();
+
+    system.run(100);
+
+    expect(staleCalls.length).toBe(0);
+    expect(activeCalls.length).toBe(1);
+
+    removeActive();
+  });
+
   it('call() via C++ session stops when override PC is hit', async () => {
     const subAddr = 0x410;
     // Build a tiny subroutine at 0x410: MOVE.L #$CAFEBABE,D2 ; RTS


### PR DESCRIPTION
## Summary
- share the probe/override registration logic through a helper that only removes the callback that was installed
- add a regression test proving that removing a stale override does not clear the new hook

## Testing
- timeout 60 npm run build --workspace=@m68k/common
- timeout 60 npm test --workspace=@m68k/core *(fails: musashi-node.out.mjs is missing because the wasm build step requires emcc, which is unavailable in this environment)*
- ./build.sh *(fails: emcc not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc210b95c8331b1afec96edf78dbf