### PR TITLE
Remove unused helper functions from memory bridge

### DIFF
--- a/m68k_memory_bridge.cc
+++ b/m68k_memory_bridge.cc
@@ -9,17 +9,6 @@ extern "C" {
 
 static inline uint32_t addr24(uint32_t a) { return a & 0x00FFFFFFu; }
 
-// Build big-endian words/longs from 8-bit reads to avoid host-endian issues.
-// Minimal fix: delegate multi-byte BE reads to my_read_memory to avoid
-// double big-endian composition and keep behavior consistent with JS handlers.
-static inline unsigned int be16_read(uint32_t a) {
-    return my_read_memory(addr24(a), 2);
-}
-
-static inline unsigned int be32_read(uint32_t a) {
-    return my_read_memory(addr24(a), 4);
-}
-
 extern "C" {
 
 // ---- Data read/write callbacks ----


### PR DESCRIPTION
## Summary
- remove the unused `be16_read` and `be32_read` helpers from the memory bridge so the file only exposes the active entry points

## Testing
- timeout 60 npm test --workspace=@m68k/core *(fails: TypeScript cannot resolve @m68k/common within the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc210b95c8331b1afec96edf78dbf