### PR TITLE
Release musashi-wasm 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2025-09-20
+
+### 🐛 Bug Fixes
+
+- **npm package completeness**: Publish the Musashi Node loader (`musashi-node.out.mjs`) and WASM binaries alongside the browser build so Node integrations work without vendoring artifacts.
+
+### 🛠️ Tooling
+
+- **Packaging guardrails**: Fail npm packaging if the Musashi Node build is missing and mirror the `.wasm.map` into both `dist/` and the package root to keep artifacts in sync.
+
 ## [0.1.8] - 2025-09-19
 
 ### 🚀 Improvements

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [
@@ -8,7 +8,10 @@
     "lib",
     "index-browser.mjs",
     "index.mjs",
-    "perf.mjs"
+    "perf.mjs",
+    "musashi-node.out.mjs",
+    "musashi-node.out.wasm",
+    "musashi-node.out.wasm.map"
   ],
   "exports": {
     ".": {
@@ -22,7 +25,13 @@
     "./perfetto": {
       "import": "./lib/perfetto.mjs",
       "types": "./lib/index.d.ts"
-    }
+    },
+    "./node": {
+      "import": "./musashi-node.out.mjs"
+    },
+    "./musashi-node.out.mjs": "./musashi-node.out.mjs",
+    "./musashi-node.out.wasm": "./musashi-node.out.wasm",
+    "./musashi-node.out.wasm.map": "./musashi-node.out.wasm.map"
   },
   "types": "./lib/index.d.ts",
   "main": "./index.mjs",


### PR DESCRIPTION
## Summary
- package musashi-wasm 0.1.9 to include the Node loader and wasm artifacts
- fail packaging when the musashi-node build is missing to avoid empty npm releases
- document the change in the changelog