### PR TITLE
Fix npm publish packaging for musashi-node

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -193,6 +193,15 @@ jobs:
           cp ci-artifacts/wasm-perfetto-modules/musashi-universal.out.wasm npm-package/dist/musashi-perfetto.wasm
           cp ci-artifacts/wasm-perfetto-modules/musashi-universal.out.mjs  npm-package/dist/musashi-perfetto-loader.mjs
 
+          # Stage Node-specific build from wasm-modules (Node-targeted ESM)
+          echo "Staging Node-specific WASM build (Node ESM)..."
+          cp ci-artifacts/wasm-modules/musashi-node.out.mjs  npm-package/musashi-node.out.mjs
+          cp ci-artifacts/wasm-modules/musashi-node.out.wasm npm-package/musashi-node.out.wasm
+
+          if [ -f ci-artifacts/wasm-modules/musashi-node.out.wasm.map ]; then
+            cp ci-artifacts/wasm-modules/musashi-node.out.wasm.map npm-package/musashi-node.out.wasm.map
+          fi
+
           # Verify all files are present
           echo "Verifying staged files..."
           for file in musashi.wasm musashi-loader.mjs musashi-perfetto.wasm musashi-perfetto-loader.mjs; do
@@ -202,6 +211,21 @@ jobs:
             fi
             echo "✓ $file ($(stat -c%s "npm-package/dist/$file") bytes)"
           done
+
+          echo "Verifying Node-specific files..."
+          for file in musashi-node.out.mjs musashi-node.out.wasm; do
+            if [ ! -f "npm-package/$file" ]; then
+              echo "ERROR: Missing required file: $file"
+              exit 1
+            fi
+            echo "✓ $file ($(stat -c%s "npm-package/$file") bytes)"
+          done
+
+          if [ -f npm-package/musashi-node.out.wasm.map ]; then
+            echo "✓ musashi-node.out.wasm.map ($(stat -c%s "npm-package/musashi-node.out.wasm.map") bytes)"
+          else
+            echo "ℹ️ musashi-node.out.wasm.map not provided (optional)"
+          fi
 
           # Validate and set version
           VERSION_RAW='${{ steps.validate.outputs.tag }}'
@@ -218,7 +242,7 @@ jobs:
           {
             "name": "musashi-wasm",
             "version": "0.0.0",
-            "description": "M68k Musashi WebAssembly (default and Perfetto profiling builds)",
+            "description": "M68k Musashi WebAssembly (default, Node, and Perfetto profiling builds)",
             "license": "MIT",
             "author": "mblsha",
             "repository": {
@@ -242,13 +266,20 @@ jobs:
               },
               "./perf": {
                 "import": "./perf.mjs"
-              }
+              },
+              "./node": {
+                "import": "./musashi-node.out.mjs"
+              },
+              "./musashi-node.out.mjs": "./musashi-node.out.mjs",
+              "./musashi-node.out.wasm": "./musashi-node.out.wasm"
             },
             "main": "./index.mjs",
             "files": [
               "dist/*",
               "index.mjs",
               "perf.mjs",
+              "musashi-node.out.mjs",
+              "musashi-node.out.wasm",
               "README.md",
               "LICENSE"
             ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2025-09-22
+
+### 🐛 Bug Fixes
+
+- **npm package completeness**: Copy `musashi-node.out.{mjs,wasm}` into the published tarball and expose a `node` export so backend provisioning works without vendored artifacts.
+
+### 🛠️ Tooling
+
+- **Release automation**: Update the npm publish workflow to stage the Node-specific build from CI artifacts and include it in the package manifest.
+
 ## [0.1.9] - 2025-09-20
+
+> ⚠️ This release was published without the Musashi Node artifacts due to a packaging regression. Please use 0.1.10 instead.
 
 ### 🐛 Bug Fixes
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- copy the musashi-node loader and wasm from CI artifacts during npm publish
- expose the node entrypoints in the generated package manifest and document 0.1.10
- bump the internal package version to 0.1.10 for the follow-up release

## Testing
- timeout 60 npm run build --workspace musashi-wasm
- timeout 60 npm pack