### PR TITLE
Fix npm publish workspace install

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Install dependencies and build core runtime
         run: |
           npm ci
+          npm ci --workspaces
           npm run build --workspace @m68k/core
 
       - name: Prepare npm package from CI artifacts


### PR DESCRIPTION
## Summary
- run npm ci --workspaces before building @m68k/core so release packaging picks up dependencies

## Testing
- n/a (workflow change)