### PR TITLE
Fix npm publish workspace install (take 2)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -181,8 +181,7 @@ jobs:
 
       - name: Install dependencies and build core runtime
         run: |
-          npm ci
-          npm ci --workspaces
+          npm ci --workspaces --include-workspace-root
           npm run build --workspace @m68k/core
 
       - name: Prepare npm package from CI artifacts


### PR DESCRIPTION
## Summary
- use npm ci --workspaces --include-workspace-root so the release job installs deps for @m68k/core before building

## Testing
- n/a (workflow change)