### PR TITLE
Release musashi-wasm 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-23
+
+### ✨ Features
+
+- **Core fusion wrapper**: Ship the compiled `@m68k/core` runtime and wasm shim as part of the `musashi-wasm` npm package so downstream tooling can call `import { createSystem } from 'musashi-wasm/core'` without vendoring sources.
+
+### 🛠️ Tooling
+
+- **Node typings & publish flow**: Bundle a `musashi-wasm/node` declaration file, extend package exports/tests to guard the new surface, and update the publish workflow to stage the new assets before uploading to npm.
+
 ## [0.1.11] - 2025-09-23
+
+> ⚠️ Release superseded. Publishing to npm failed for this tag; use 0.1.12 instead.
 
 ### ✨ Features
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump musashi-wasm to 0.1.12 and note 0.1.11 was superseded after the publish workflow fix

## Testing
- timeout 60 npm run build --workspace musashi-wasm
- timeout 60 npx jest npm-package/test/package-files.test.js
- timeout 60 npm pack --workspace musashi-wasm