### PR TITLE
Build workspace deps before core in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -182,6 +182,7 @@ jobs:
       - name: Install dependencies and build core runtime
         run: |
           npm ci --workspaces --include-workspace-root
+          npm run build --workspace @m68k/common
           npm run build --workspace @m68k/core
 
       - name: Prepare npm package from CI artifacts


### PR DESCRIPTION
## Summary
- build @m68k/common before @m68k/core so TypeScript has the dependency declarations during npm publish

## Testing
- n/a (workflow change)