### PR TITLE
Simplify npm publish to use prebuilt core

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -179,11 +179,8 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies and build core runtime
-        run: |
-          npm ci --workspaces --include-workspace-root
-          npm run build --workspace @m68k/common
-          npm run build --workspace @m68k/core
+      - name: Install workspace dependencies
+        run: npm ci --workspaces --include-workspace-root
 
       - name: Prepare npm package from CI artifacts
         shell: bash
@@ -231,13 +228,38 @@ jobs:
             echo "✓ musashi-node.out.wasm.map ($(stat -c%s "npm-package/musashi-node.out.wasm.map") bytes)"
           fi
 
-          echo "Generating wrapper libraries via npm script..."
-          npm run build --prefix npm-package
+          echo "Syncing wasm artifacts into lib/wasm..."
+          mkdir -p npm-package/lib/wasm
+          cp ci-artifacts/wasm-modules/musashi.out.mjs npm-package/lib/wasm/musashi.out.mjs
+          cp ci-artifacts/wasm-modules/musashi.out.wasm npm-package/lib/wasm/musashi.out.wasm
+          cp ci-artifacts/wasm-modules/musashi-universal.out.mjs npm-package/lib/wasm/musashi-universal.out.mjs
+          cp ci-artifacts/wasm-modules/musashi-universal.out.wasm npm-package/lib/wasm/musashi-universal.out.wasm
+          cp ci-artifacts/wasm-modules/musashi-node.out.mjs npm-package/lib/wasm/musashi-node.out.mjs
+          cp ci-artifacts/wasm-modules/musashi-node.out.wasm npm-package/lib/wasm/musashi-node.out.wasm
+          if [ -f ci-artifacts/wasm-modules/musashi-node.out.wasm.map ]; then
+            cp ci-artifacts/wasm-modules/musashi-node.out.wasm.map npm-package/lib/wasm/musashi-node.out.wasm.map
+          fi
+
+          echo "Ensuring musashi-wasm/node typings are present..."
+          cat <<'EOF' > npm-package/musashi-node.d.ts
+declare module 'musashi-wasm/node' {
+  export interface MusashiNodeInitOptions {
+    locateFile?: (path: string, prefix?: string) => string;
+    [key: string]: unknown;
+  }
+
+  export type MusashiNodeFactory = (options?: MusashiNodeInitOptions) => Promise<unknown>;
+
+  const init: MusashiNodeFactory;
+
+  export default init;
+}
+EOF
 
           echo "Validating bundled core runtime..."
           for file in lib/core/index.js lib/core/index.d.ts lib/wasm/musashi-node-wrapper.mjs; do
             if [ ! -f "npm-package/$file" ]; then
-              echo "ERROR: Missing generated file: $file"
+              echo "ERROR: Missing required file: $file"
               exit 1
             fi
           done


### PR DESCRIPTION
## Summary
- drop the TypeScript rebuild during npm release packaging and rely on the committed dist files
- copy the fresh wasm artifacts into lib/wasm and rewrite the musashi-wasm/node typings during packaging

## Testing
- n/a (workflow change)