### PR TITLE
Run npm publish workflow on tag pushes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@ name: Publish to npm (reuse CI artifacts)
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag_name:
@@ -12,7 +15,7 @@ on:
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:
-  group: npm-publish-${{ github.event.release.tag_name || inputs.tag_name }}
+  group: npm-publish-${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -31,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event.release.tag_name || inputs.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}
 
       - name: Install jq
         run: |
@@ -43,7 +46,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${{ github.event.release.tag_name || inputs.tag_name }}"
+          TAG="${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}"
           COMMIT="$(git rev-parse HEAD)"
           
           echo "Tag: $TAG"
@@ -318,7 +321,7 @@ EOF
         if: failure()
         run: |
           echo "❌ NPM publish workflow failed"
-          echo "Release: ${{ github.event.release.tag_name || inputs.tag_name }}"
+          echo "Release: ${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}"
           echo "Please check the logs above for specific error details"
           echo "Common issues:"
           echo "  - WebAssembly CI not completed or failed"


### PR DESCRIPTION
## Summary
- trigger the publish workflow when a version tag is pushed so releases run regardless of the release event
- fall back to github.ref_name when computing the tag name and concurrency key

## Testing
- n/a (workflow change)