### PR TITLE
Simplify publish workflow triggers

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,16 +6,10 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: 'Tag to publish (e.g., v0.1.1)'
-        required: true
-        type: string
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:
-  group: npm-publish-${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+  group: npm-publish-${{ github.event.release.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -34,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          ref: ${{ github.event.release.tag_name || github.ref_name }}
 
       - name: Install jq
         run: |
@@ -46,7 +40,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}"
+          TAG="${{ github.event.release.tag_name || github.ref_name }}"
           COMMIT="$(git rev-parse HEAD)"
           
           echo "Tag: $TAG"
@@ -327,7 +321,7 @@ EOF
         if: failure()
         run: |
           echo "❌ NPM publish workflow failed"
-          echo "Release: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}"
+          echo "Release: ${{ github.event.release.tag_name || github.ref_name }}"
           echo "Please check the logs above for specific error details"
           echo "Common issues:"
           echo "  - WebAssembly CI not completed or failed"


### PR DESCRIPTION
## Summary
- drop workflow_dispatch input handling and rely on release/tag refs for npm publish workflow
- avoid referencing undefined contexts so tag pushes actually start the job

## Testing
- n/a (workflow-only)
