### PR TITLE
Rely on ref_name in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,7 +9,7 @@ on:
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:
-  group: npm-publish-${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+  group: npm-publish-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+          ref: ${{ github.ref_name }}
 
       - name: Install jq
         run: |
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          TAG="${{ github.ref_name }}"
           COMMIT="$(git rev-parse HEAD)"
           
           echo "Tag: $TAG"
@@ -321,7 +321,7 @@ EOF
         if: failure()
         run: |
           echo "❌ NPM publish workflow failed"
-          echo "Release: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}"
+          echo "Release: ${{ github.ref_name }}"
           echo "Please check the logs above for specific error details"
           echo "Common issues:"
           echo "  - WebAssembly CI not completed or failed"


### PR DESCRIPTION
## Summary
- use github.ref_name for concurrency, checkout, and tag resolution to avoid missing release payloads on tag pushes

## Testing
- n/a (workflow-only)
