### PR TITLE
Skip publish workflow on branch pushes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: read
       id-token: write   # provenance for npm


### PR DESCRIPTION
## Summary
- add a job-level guard so the npm publish workflow runs only for tag refs

## Testing
- n/a (workflow-only)
