### PR TITLE
Allow release events to run publish job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: read
       id-token: write   # provenance for npm


### PR DESCRIPTION
## Summary
- let npm publish workflow run when triggered by a release event as well as tag pushes

## Testing
- n/a (workflow-only)
