### PR TITLE
Allow manual publish runs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger so npm publish workflow can be invoked manually when needed

## Testing
- n/a (workflow-only)
