### PR TITLE
Allow manual publish runs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:


### PR DESCRIPTION
## Summary
- add workflow_dispatch trigger so we can manually run npm publish workflow when tags misfire

## Testing
- n/a (workflow-only)
