### PR TITLE
Use empty map for workflow_dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 # Prevent concurrent runs that could interfere with each other
 concurrency:


### PR DESCRIPTION
## Summary
- set workflow_dispatch to an explicit empty mapping so GitHub treats it as a valid manual trigger

## Testing
- n/a (workflow-only)
