### PR TITLE
Fix npm publish workflow: build dependencies in correct order

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -180,8 +180,10 @@ jobs:
       - name: Install workspace dependencies
         run: npm ci --workspaces --include-workspace-root
 
-      - name: Build core runtime
-        run: npm run build --workspace=@m68k/core
+      - name: Build workspace packages
+        run: |
+          npm run build --workspace=@m68k/common
+          npm run build --workspace=@m68k/core
 
       - name: Prepare npm package from CI artifacts
         shell: bash


### PR DESCRIPTION
## 🐛 Critical Hotfix 

The v0.1.11 release failed because the npm publish workflow tries to build  without building its dependency  first.

### Problem


### Solution
Build  before  in the CI workflow:

```bash
npm run build --workspace=@m68k/common
npm run build --workspace=@m68k/core
```

### Testing
This fixes the TypeScript compilation error that prevented the v0.1.11 release from completing.

**Urgency**: This blocks npm package publication for the core wrapper APIs.