### PR TITLE
Fix npm provenance URLs for v0.1.11 release

### DIFF
--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -61,12 +61,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mblsha/Musashi.git"
+    "url": "https://github.com/mblsha/musashi-wasm.git"
   },
   "bugs": {
-    "url": "https://github.com/mblsha/Musashi/issues"
+    "url": "https://github.com/mblsha/musashi-wasm/issues"
   },
-  "homepage": "https://github.com/mblsha/Musashi#readme"
+  "homepage": "https://github.com/mblsha/musashi-wasm#readme"
   ,
   "scripts": {
     "build": "node ./scripts/generate-wrapper.js",


### PR DESCRIPTION
## 🔧 Provenance Fix

The v0.1.11 npm publish failed due to provenance verification mismatch:

**Error**: `package.json` "repository.url" is "git+https://github.com/mblsha/Musashi.git", expected to match "https://github.com/mblsha/musashi-wasm" from provenance

### Changes
- Updated repository URL: `musashi-wasm.git` (was `Musashi.git`)
- Updated bugs URL: `musashi-wasm/issues` (was `Musashi/issues`)  
- Updated homepage: `musashi-wasm#readme` (was `Musashi#readme`)

### Impact
This allows npm publish with provenance to succeed for secure package publication.

**Urgency**: Critical for v0.1.11 release completion