### PR TITLE
Bundle core runtime into musashi-wasm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ lerna-debug.log*
 npm-package/dist/
 npm-package/lib/*.mjs
 npm-package/lib/core/
+npm-package/lib/wasm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
-- **Core wrapper**: Export compiled `@m68k/core` runtime as `musashi-wasm/core` for `import { createSystem }` without vendoring
+- **Core wrapper**: Bundle the `@m68k/common` and `@m68k/core` sources directly into `musashi-wasm/core`, so `import { createSystem } from 'musashi-wasm/core'` works without extra packages
 - **Node typings**: Add TypeScript definitions for `musashi-wasm/node` import path
 
 ## [0.1.10] - 2025-09-22

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Motorola M68000 CPU emulator (v4.10) compiled to WebAssembly with TypeScript b
 
 - **M68k CPU Emulation**: Supports 68000, 68010, 68EC020, 68020, 68EC030, 68030, 68EC040, 68040
 - **WebAssembly Target**: Runs in browsers and Node.js
-- **TypeScript API**: Clean, type-safe interface via `@m68k/core` and `@m68k/memory` packages
+- **TypeScript API**: Clean, type-safe interface via `musashi-wasm/core` and `musashi-wasm/memory` packages
 - **Perfetto Tracing**: Optional performance profiling with Chrome's tracing format
 - **Memory Hooks**: Custom memory access handlers
 - **PC Hooks**: Breakpoint and code patching support
@@ -20,7 +20,7 @@ A Motorola M68000 CPU emulator (v4.10) compiled to WebAssembly with TypeScript b
 ### Using the TypeScript API
 
 ```typescript
-import { createSystem } from '@m68k/core';
+import { createSystem } from 'musashi-wasm/core';
 
 // Create a system with ROM and RAM
 const system = await createSystem({
@@ -78,8 +78,8 @@ SKIP_WASM_BUILD=1 ./test_with_real_wasm.sh
 
 The TypeScript API is organized into modular packages:
 
-- **[@m68k/core](packages/core)** - Core emulator with CPU control, memory access, and hooks
-- **[@m68k/memory](packages/memory)** - Memory utilities for structured data access
+- **`musashi-wasm/core`** (source: [packages/core](packages/core)) - Core emulator with CPU control, memory access, and hooks
+- **`musashi-wasm/memory`** (source: [packages/memory](packages/memory)) - Memory utilities for structured data access
 
 See [packages/README.md](packages/README.md) for detailed documentation.
 
@@ -159,8 +159,8 @@ Both hook functions should return 0 to continue execution, or non-zero to break 
 ├── m68k_perfetto.cc    # Perfetto integration
 ├── build.sh            # WebAssembly build script (bash)
 ├── packages/           # TypeScript packages
-│   ├── core/          # @m68k/core package
-│   └── memory/        # @m68k/memory package
+│   ├── core/          # Source for musashi-wasm/core runtime
+│   └── memory/        # Source for musashi-wasm/memory helpers
 └── musashi-wasm-test/ # Integration tests
 ```
 

--- a/npm-package/lib/index.d.ts
+++ b/npm-package/lib/index.d.ts
@@ -1,10 +1,8 @@
 import type {
-  M68kRegister as CommonM68kRegister,
-  ReadMemoryCallback as CommonReadMemoryCallback,
-  WriteMemoryCallback as CommonWriteMemoryCallback,
-  PCHookCallback as CommonPCHookCallback,
-} from '@m68k/common';
-import type {
+  M68kRegister as CoreM68kRegister,
+  ReadMemoryCallback as CoreReadMemoryCallback,
+  WriteMemoryCallback as CoreWriteMemoryCallback,
+  PCHookCallback as CorePCHookCallback,
   System as CoreSystem,
   SystemConfig as CoreSystemConfig,
   CpuRegisters as CoreCpuRegisters,
@@ -12,10 +10,15 @@ import type {
   Tracer as CoreTracer,
   TraceConfig as CoreTraceConfig,
   SymbolMap as CoreSymbolMap,
-} from '@m68k/core';
+  MemoryAccessCallback as CoreMemoryAccessCallback,
+  MemoryAccessEvent as CoreMemoryAccessEvent,
+  MemoryLayout as CoreMemoryLayout,
+  MemoryRegion as CoreMemoryRegion,
+  MirrorRegion as CoreMirrorRegion,
+} from './core/index.js';
 
 declare module 'musashi-wasm' {
-  export { createSystem, M68kRegister } from '@m68k/core';
+  export { createSystem, M68kRegister } from './core/index.js';
   export type System = CoreSystem;
   export type SystemConfig = CoreSystemConfig;
   export type CpuRegisters = CoreCpuRegisters;
@@ -23,6 +26,11 @@ declare module 'musashi-wasm' {
   export type Tracer = CoreTracer;
   export type TraceConfig = CoreTraceConfig;
   export type SymbolMap = CoreSymbolMap;
+  export type MemoryAccessCallback = CoreMemoryAccessCallback;
+  export type MemoryAccessEvent = CoreMemoryAccessEvent;
+  export type MemoryLayout = CoreMemoryLayout;
+  export type MemoryRegion = CoreMemoryRegion;
+  export type MirrorRegion = CoreMirrorRegion;
 
   export interface MusashiModule {
     _m68k_init(): void;
@@ -46,10 +54,10 @@ declare module 'musashi-wasm' {
     allocateUTF8(str: string): number;
   }
 
-  export type M68kRegister = CommonM68kRegister;
-  export type ReadMemoryCallback = CommonReadMemoryCallback;
-  export type WriteMemoryCallback = CommonWriteMemoryCallback;
-  export type PCHookCallback = CommonPCHookCallback;
+  export type M68kRegister = CoreM68kRegister;
+  export type ReadMemoryCallback = CoreReadMemoryCallback;
+  export type WriteMemoryCallback = CoreWriteMemoryCallback;
+  export type PCHookCallback = CorePCHookCallback;
 
   export class Musashi {
     constructor();

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -72,9 +72,7 @@
     "build": "node ./scripts/generate-wrapper.js",
     "prepare": "npm run build"
   },
-  "dependencies": {
-    "@m68k/common": "^0.1.0"
-  },
+  "dependencies": {},
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "^6.13.0",
         "@typescript-eslint/parser": "^6.13.0",
+        "dts-bundle-generator": "^9.5.1",
+        "esbuild": "^0.25.10",
         "eslint": "^8.54.0",
         "prettier": "^3.1.0",
         "typescript": "^5.3.3"
@@ -526,6 +528,422 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -2111,6 +2529,22 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dts-bundle-generator": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-9.5.1.tgz",
+      "integrity": "sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==",
+      "dev": true,
+      "dependencies": {
+        "typescript": ">=5.0.2",
+        "yargs": "^17.6.0"
+      },
+      "bin": {
+        "dts-bundle-generator": "dist/bin/dts-bundle-generator.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.200",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz",
@@ -2146,6 +2580,47 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
+    "dts-bundle-generator": "^9.5.1",
+    "esbuild": "^0.25.10",
     "eslint": "^8.54.0",
     "prettier": "^3.1.0",
     "typescript": "^5.3.3"

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,9 +4,9 @@ This directory contains TypeScript packages for the M68k emulator with optional 
 
 ## Packages
 
-### @m68k/core
+### musashi-wasm/core
 
-The core M68k emulator package that provides:
+Bundled runtime exported from the npm package (`packages/core` workspace is published internally as `@m68k/core`). It provides:
 - Low-level CPU emulation via WebAssembly
 - Memory access (read/write)
 - Register manipulation
@@ -14,9 +14,9 @@ The core M68k emulator package that provides:
 - Hook system (probe and override)
 - Optional Perfetto tracing support
 
-### @m68k/memory
+### musashi-wasm/memory
 
-Memory utilities for structured access to M68k memory:
+Memory utilities bundled with the npm package (`packages/memory` workspace name is `@m68k/memory`):
 - `MemoryRegion`: Type-safe access to fixed memory structures
 - `MemoryArray`: Array-like access to collections of structures
 - `DataParser`: Utilities for parsing big-endian data
@@ -24,8 +24,8 @@ Memory utilities for structured access to M68k memory:
 ## Quick Start
 
 ```typescript
-import { createSystem } from '@m68k/core';
-import { MemoryRegion, DataParser } from '@m68k/memory';
+import { createSystem } from 'musashi-wasm/core';
+import { MemoryRegion, DataParser } from 'musashi-wasm/memory';
 
 // Create a system with ROM and RAM
 const system = await createSystem({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,9 @@ import type {
   SymbolMap,
   MemoryAccessCallback,
   MemoryAccessEvent,
+  MemoryLayout,
+  MemoryRegion,
+  MirrorRegion,
 } from './types.js';
 import { M68kRegister } from '@m68k/common';
 import { MusashiWrapper, getModule } from './musashi-wrapper.js';
@@ -21,8 +24,18 @@ export type {
   Tracer,
   TraceConfig,
   SymbolMap,
+  MemoryAccessCallback,
+  MemoryAccessEvent,
+  MemoryLayout,
+  MemoryRegion,
+  MirrorRegion,
 };
 export { M68kRegister } from '@m68k/common';
+export type {
+  ReadMemoryCallback,
+  WriteMemoryCallback,
+  PCHookCallback,
+} from '@m68k/common';
 
 // --- Private Implementation ---
 


### PR DESCRIPTION
## Summary
- bundle @m68k/common + @m68k/core sources into the musashi-wasm/core export via esbuild during packaging
- generate a unified declaration bundle and update docs to reference the new musashi-wasm/* entry points
- drop the unpublished dependency and stage wasm wrappers so musashi-wasm/core can import musashi-wasm/node at runtime

## Testing
- npm --prefix npm-package run build
- npm pack (npm-package)
- manual: install packed tarball into a temp project and import musashi-wasm/core
- timeout 60 npm run build --workspace=@m68k/core
