### PR TITLE
Release 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.13] - 2025-09-25
+## [0.1.12] - 2025-09-25
 
 ### ✨ Features
 

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump musashi-wasm package to 0.1.12 and capture the changelog entry

## Testing
- npm --prefix npm-package run build
- npm pack (npm-package)
- manual: install packed tarball into temp project and import musashi-wasm/core
- timeout 60 npm run build --workspace=@m68k/core
