### PR TITLE
Reset npm package version for 0.1.12 release

### DIFF
--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musashi-wasm",
-  "version": "0.1.12",
+  "version": "0.1.11",
   "description": "WebAssembly port of the Musashi M68000 CPU emulator with optional Perfetto tracing support",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- set npm-package/package.json back to 0.1.11 so the publish workflow can bump to 0.1.12 itself

## Testing
- none (metadata change only)