### PR TITLE
Fix publish workflow for new entrypoint layout

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -234,8 +234,14 @@ jobs:
           echo "Rebuilding npm-package wrapper to stage core runtime..."
           npm --prefix npm-package run build
 
-          echo "Validating top-level ESM wrappers..."
-          for file in index.mjs perf.mjs; do
+          echo "Validating ESM entrypoints..."
+          TOP_LEVEL_FILES=(
+            "lib/index.mjs"
+            "lib/index.d.ts"
+            "perf.mjs"
+          )
+
+          for file in "${TOP_LEVEL_FILES[@]}"; do
             if [ ! -f "npm-package/$file" ]; then
               echo "ERROR: Missing required file: $file"
               exit 1


### PR DESCRIPTION
## Summary
- update the npm publish workflow to validate the generated  entrypoints instead of the removed root 
- keep the perf entrypoint in the required list to ensure we still ship it

## Testing
- not run (workflow change only)