### PR TITLE
docs: clarify npm vs git usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ const { cycles: c1, startPc, endPc } = system.step();
 console.log(`Stepped ${c1} cycles from 0x${startPc.toString(16)} to 0x${endPc.toString(16)}`);
 ```
 
+### Installation Notes
+
+- **Use the npm release for consumption**: the published tarball (`npm install musashi-wasm`) bundles the prebuilt `musashi-wasm/core` and `musashi-wasm/memory` entry points. Those artifacts are intentionally excluded from git, so `npm install musashi-wasm@github:mblsha/musashi-wasm#<sha>` will only produce the raw workspaces and WebAssembly objects.
+- **Need to recreate the bundle locally?** After cloning, run `npm --prefix npm-package run build` (or the full `./run-tests-ci.sh` pipeline) to regenerate `npm-package/lib/**` before testing imports such as `import { createSystem } from 'musashi-wasm/core'`.
+- **Git checkouts are source-first**: the files under `packages/core/dist` are build outputs. They stay untracked so the repository can remain lean for development workflows.
+
 ### Building from Source
 
 ```bash

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,6 +2,8 @@
 
 This directory contains TypeScript packages for the M68k emulator with optional Perfetto tracing support.
 
+> **Heads-up:** `musashi-wasm/core` and `musashi-wasm/memory` are distributed prebuilt on npm. Git checkouts only include the TypeScript sources plus the WASM assets; `packages/*/dist` and `npm-package/lib/**` stay untracked by design. To exercise the bundled entrypoints locally, install the published package (`npm install musashi-wasm`) or regenerate the wrapper after cloning via `npm --prefix npm-package run build` / `./run-tests-ci.sh`.
+
 ## Packages
 
 ### musashi-wasm/core


### PR DESCRIPTION
## Summary
- document that git checkouts exclude the bundled musashi-wasm/core artifacts
- steer consumers toward the published npm package for ready-to-use imports
- point local developers at npm --prefix npm-package run build or run-tests-ci.sh when they need to regenerate the bundle

## Testing
- not run (docs only)
