### PR TITLE
Fix browser packaging for musashi-wasm

### DIFF
--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -7,6 +7,9 @@
     "dist/**",
     "lib/**",
     "perf.mjs",
+    "musashi.out.mjs",
+    "musashi.out.wasm",
+    "musashi.out.wasm.map",
     "musashi-node.out.mjs",
     "musashi-node.out.wasm",
     "musashi-node.out.wasm.map",
@@ -43,6 +46,9 @@
       "import": "./lib/memory/index.js",
       "types": "./lib/memory/index.d.ts"
     },
+    "./musashi.out.mjs": "./musashi.out.mjs",
+    "./musashi.out.wasm": "./musashi.out.wasm",
+    "./musashi.out.wasm.map": "./musashi.out.wasm.map",
     "./musashi-node.out.mjs": "./musashi-node.out.mjs",
     "./musashi-node.out.wasm": "./musashi-node.out.wasm",
     "./musashi-node.out.wasm.map": "./musashi-node.out.wasm.map"
@@ -73,7 +79,8 @@
   ,
   "scripts": {
     "build": "node ./scripts/generate-wrapper.js",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test:browser": "playwright test"
   },
   "dependencies": {},
   "publishConfig": {

--- a/npm-package/playwright.config.ts
+++ b/npm-package/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './test/browser',
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    browserName: 'chromium',
+    headless: true,
+  },
+});

--- a/npm-package/test/browser/index.html
+++ b/npm-package/test/browser/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>musashi-wasm browser smoke test</title>
+  </head>
+  <body>
+    <pre id="status">initializing...</pre>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/npm-package/test/browser/main.js
+++ b/npm-package/test/browser/main.js
@@ -1,0 +1,20 @@
+import { createSystem } from '../../lib/core/index.js';
+
+const statusNode = document.getElementById('status');
+if (!(statusNode instanceof HTMLElement)) {
+  throw new Error('status element missing');
+}
+const statusEl = statusNode;
+
+async function run() {
+  const rom = new Uint8Array(0x2000);
+  try {
+    await createSystem({ rom, ramSize: 0x2000 });
+    statusEl.textContent = 'createSystem: ok';
+  } catch (error) {
+    console.error('createSystem failed', error);
+    statusEl.textContent = `error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+run();

--- a/npm-package/test/browser/playwright.spec.ts
+++ b/npm-package/test/browser/playwright.spec.ts
@@ -1,0 +1,93 @@
+import { createServer, Server } from 'http';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { expect, test } from '@playwright/test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '..', '..');
+
+const mimeTypes = new Map<string, string>([
+  ['.html', 'text/html; charset=utf-8'],
+  ['.js', 'application/javascript; charset=utf-8'],
+  ['.mjs', 'application/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.map', 'application/json; charset=utf-8'],
+  ['.wasm', 'application/wasm']
+]);
+
+const resolveContentType = (filePath: string): string => {
+  const ext = path.extname(filePath);
+  return mimeTypes.get(ext) ?? 'application/octet-stream';
+};
+
+test.describe('musashi-wasm browser bundle', () => {
+  let server: Server | null = null;
+  let baseUrl: string;
+
+  test.beforeAll(async () => {
+    server = createServer(async (req, res) => {
+      try {
+        const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+        let pathname = decodeURIComponent(requestUrl.pathname);
+        if (pathname.endsWith('/')) {
+          pathname = `${pathname}index.html`;
+        }
+        const relativePath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+        const filePath = path.resolve(packageRoot, relativePath);
+        if (!filePath.startsWith(packageRoot)) {
+          res.statusCode = 403;
+          res.end('Forbidden');
+          return;
+        }
+        const fileData = await fs.readFile(filePath);
+        res.statusCode = 200;
+        res.setHeader('Content-Type', resolveContentType(filePath));
+        res.end(fileData);
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === 'ENOENT') {
+          res.statusCode = 404;
+          res.end('Not found');
+        } else {
+          res.statusCode = 500;
+          res.end('Internal server error');
+        }
+      }
+    });
+
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to start HTTP server');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  test.afterAll(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve) => server!.close(() => resolve()))
+      .finally(() => {
+        server = null;
+      });
+  });
+
+  test('createSystem loads in a real browser', async ({ page }) => {
+    const errors: Error[] = [];
+    page.on('pageerror', (err) => {
+      errors.push(err);
+    });
+
+    await page.goto(`${baseUrl}/test/browser/index.html`);
+
+    const statusLocator = page.locator('#status');
+    await expect(statusLocator).toHaveText('createSystem: ok', { timeout: 30_000 });
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.44.0",
         "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "^6.13.0",
         "@typescript-eslint/parser": "^6.13.0",
@@ -1472,6 +1473,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4731,6 +4747,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:wasm": "npm run build:wasm && npm run test:with-wasm"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",

--- a/run-tests-ci.sh
+++ b/run-tests-ci.sh
@@ -60,4 +60,15 @@ if ! timeout 30 node npm-package/test/integration.mjs; then
   exit $rc
 fi
 
+echo "Running npm-package browser smoke test (60s timeout)..."
+if ! timeout 60 npm --prefix npm-package run test:browser; then
+  rc=$?
+  if [[ $rc -eq 124 ]]; then
+    echo "npm-package browser smoke test timed out after 60s" >&2
+  else
+    echo "npm-package browser smoke test failed with exit code ${rc}" >&2
+  fi
+  exit $rc
+fi
+
 echo "All tests completed"


### PR DESCRIPTION
## Summary
- ship the browser loader/wasm in the npm package and expose them via files/exports
- make the runtime wrappers detect browser vs node and import the correct Emscripten build
- add a Playwright-based browser smoke test and hook it into run-tests-ci.sh

## Testing
- timeout 60 npm test --workspace=@m68k/core
- timeout 60 npm --prefix npm-package run build
- timeout 30 node npm-package/test/integration.mjs
- timeout 60 npm --prefix npm-package run test:browser
