### PR TITLE
Fix npm publish workflow for browser artifacts

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -210,6 +210,14 @@ jobs:
             cp ci-artifacts/wasm-modules/musashi-node.out.wasm.map npm-package/musashi-node.out.wasm.map
           fi
 
+          # Stage browser-targeted universal build expected by packaging script
+          echo "Staging browser WASM build (Universal ESM)..."
+          cp ci-artifacts/wasm-modules/musashi-universal.out.mjs  musashi.out.mjs
+          cp ci-artifacts/wasm-modules/musashi-universal.out.wasm musashi.out.wasm
+          if [ -f ci-artifacts/wasm-modules/musashi-universal.out.wasm.map ]; then
+            cp ci-artifacts/wasm-modules/musashi-universal.out.wasm.map musashi.out.wasm.map
+          fi
+
           echo "Verifying staged WASM artifacts..."
           for file in musashi.wasm musashi-loader.mjs musashi-perfetto.wasm musashi-perfetto-loader.mjs; do
             if [ ! -f "npm-package/dist/$file" ]; then
@@ -230,6 +238,14 @@ jobs:
           if [ -f npm-package/musashi-node.out.wasm.map ]; then
             echo "✓ musashi-node.out.wasm.map ($(stat -c%s "npm-package/musashi-node.out.wasm.map") bytes)"
           fi
+
+          for file in musashi.out.mjs musashi.out.wasm; do
+            if [ ! -f "$file" ]; then
+              echo "ERROR: Missing required browser artifact: $file"
+              exit 1
+            fi
+            echo "✓ $file ($(stat -c%s "$file") bytes)"
+          done
 
           echo "Rebuilding npm-package wrapper to stage core runtime..."
           npm --prefix npm-package run build


### PR DESCRIPTION
## Summary
- copy the universal browser build from CI artifacts into the repo root before running the wrapper generator
- verify musashi.out.* files exist so the packaging script doesn’t bail out

## Testing
- none (workflow change)
