### PR TITLE
Refactor PC/PPC retrieval for fallback memory tracing

### DIFF
--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -448,13 +448,7 @@ export class MusashiWrapper {
     }
 
     if (!this._traceAvailable) {
-      const pc = mask24(this._module._m68k_get_reg(0, M68kRegister.PC) >>> 0);
-      let ppc = pc;
-      try {
-        ppc = mask24(this._module._m68k_get_reg(0, M68kRegister.PPC) >>> 0);
-      } catch {
-        ppc = pc;
-      }
+      const { pc, ppc } = this.getCurrentPcAndPpc();
       this._system._handleMemoryRead?.(addr >>> 0, size, result >>> 0, pc, ppc, 'wrapper-fallback');
     }
 
@@ -485,15 +479,20 @@ export class MusashiWrapper {
     }
 
     if (!this._traceAvailable) {
-      const pc = mask24(this._module._m68k_get_reg(0, M68kRegister.PC) >>> 0);
-      let ppc = pc;
-      try {
-        ppc = mask24(this._module._m68k_get_reg(0, M68kRegister.PPC) >>> 0);
-      } catch {
-        ppc = pc;
-      }
+      const { pc, ppc } = this.getCurrentPcAndPpc();
       this._system._handleMemoryWrite?.(addr >>> 0, size, maskedValue, pc, ppc, 'wrapper-fallback');
     }
+  }
+
+  private getCurrentPcAndPpc(): { pc: number; ppc: number } {
+    const pc = mask24(this._module._m68k_get_reg(0, M68kRegister.PC) >>> 0);
+    let ppc = pc;
+    try {
+      ppc = mask24(this._module._m68k_get_reg(0, M68kRegister.PPC) >>> 0);
+    } catch {
+      ppc = pc;
+    }
+    return { pc, ppc };
   }
 
   readRaw8(address: number): number {


### PR DESCRIPTION
## Summary
- extract a helper to centralize PC/PPC lookup for fallback memory trace notifications
- reuse the helper in the read/write paths to remove duplication and keep register handling consistent

## Testing
- timeout 60 npm test --workspace=@m68k/core *(fails: TypeScript cannot find module '@m68k/common')*


------
https://chatgpt.com/codex/tasks/task_e_68db136d35a883319177fef484d79216