### PR TITLE
Remove unused ROM state from SystemImpl and refresh docs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -217,7 +217,6 @@ class TracerImpl implements Tracer {
 class SystemImpl implements System {
   private _musashi: MusashiWrapper;
   readonly ram: Uint8Array;
-  private _rom: Uint8Array;
   private _hooks = {
     probes: new Map<number, HookCallback>(),
     overrides: new Map<number, HookCallback>(),
@@ -229,7 +228,6 @@ class SystemImpl implements System {
 
   constructor(musashi: MusashiWrapper, config: SystemConfig) {
     this._musashi = musashi;
-    this._rom = config.rom;
     this.ram = new Uint8Array(config.ramSize);
     this.tracer = new TracerImpl(musashi);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -128,9 +128,9 @@ export interface Tracer {
   /**
    * Stops the current tracing session and returns the captured data.
    * Throws an error if no session is active.
-   * @returns A promise that resolves to the trace data as a `Uint8Array`.
+   * @returns The trace data as a `Uint8Array`.
    */
-    stop(): Uint8Array;
+  stop(): Uint8Array;
 
   /**
    * Registers a map of addresses to function names. These names will appear
@@ -180,8 +180,8 @@ export interface System {
   setRegister<K extends keyof CpuRegisters>(register: K, value: number): void;
 
   /**
-   * Executes a native subroutine at the given address. The promise resolves
-   * when the subroutine returns (e.g., via an RTS instruction).
+   * Executes a native subroutine at the given address and returns when the
+   * subroutine completes (e.g., via an RTS instruction).
    * @returns The number of CPU cycles executed.
    */
   call(address: number): number;


### PR DESCRIPTION
## Summary
- remove the unused ROM field from `SystemImpl` so we do not retain dead state
- clarify Tracer and System documentation comments to describe their synchronous behavior accurately

## Testing
- npm test --workspace=@m68k/core *(fails: ts-jest cannot resolve @m68k/common in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68defe03a3c083319941cfdb63d65802