### PR TITLE
Add bounds validation to DataParser utilities

### DIFF
--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -260,5 +260,24 @@ describe('@m68k/memory', () => {
         new Uint8Array([0x4c, 0x6f, 0x6e, 0x00])
       );
     });
+
+    test('should guard against out-of-range reads and writes', () => {
+      const data = new Uint8Array([0x01, 0x02, 0x03]);
+
+      expect(() => DataParser.readUint32BE(data, 0)).toThrow(RangeError);
+      expect(() => DataParser.writeUint16BE(data, 2, 0xffff)).toThrow(
+        RangeError
+      );
+      expect(() => DataParser.readCString(data, 4)).toThrow(RangeError);
+    });
+
+    test('should require capacity for CString terminator', () => {
+      const data = new Uint8Array(2);
+
+      expect(() => DataParser.writeCString(data, 'abc', 0, 0)).toThrow(
+        'CString region must be at least 1 byte to include a terminator'
+      );
+      expect(() => DataParser.writeCString(data, 'abc', 2)).toThrow(RangeError);
+    });
   });
 });

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -78,13 +78,36 @@ export class MemoryArray<T> {
  * Helper utilities for parsing common data types from byte arrays.
  */
 export class DataParser {
+  private static ensureAvailable(
+    data: Uint8Array,
+    offset: number,
+    requiredLength: number
+  ): void {
+    if (!Number.isInteger(offset)) {
+      throw new RangeError(`Offset ${offset} must be an integer`);
+    }
+    if (offset < 0) {
+      throw new RangeError(`Offset ${offset} is out of bounds for length ${data.length}`);
+    }
+    if (requiredLength < 0) {
+      throw new RangeError('Required length must be non-negative');
+    }
+    if (offset + requiredLength > data.length) {
+      throw new RangeError(
+        `Requested ${requiredLength} byte(s) starting at offset ${offset} exceeds buffer length ${data.length}`
+      );
+    }
+  }
+
   /** Reads a big-endian 16-bit unsigned integer. */
   static readUint16BE(data: Uint8Array, offset: number = 0): number {
+    DataParser.ensureAvailable(data, offset, 2);
     return (data[offset] << 8) | data[offset + 1];
   }
 
   /** Reads a big-endian 32-bit unsigned integer. */
   static readUint32BE(data: Uint8Array, offset: number = 0): number {
+    DataParser.ensureAvailable(data, offset, 4);
     return (
       ((data[offset] << 24) |
         (data[offset + 1] << 16) |
@@ -96,6 +119,7 @@ export class DataParser {
 
   /** Reads a big-endian 16-bit signed integer. */
   static readInt16BE(data: Uint8Array, offset: number = 0): number {
+    DataParser.ensureAvailable(data, offset, 2);
     const value = (data[offset] << 8) | data[offset + 1];
     return (value << 16) >> 16; // Sign-extend
   }
@@ -113,6 +137,7 @@ export class DataParser {
     value: number,
     offset: number = 0
   ): void {
+    DataParser.ensureAvailable(data, offset, 2);
     data[offset] = (value >> 8) & 0xff;
     data[offset + 1] = value & 0xff;
   }
@@ -123,6 +148,7 @@ export class DataParser {
     value: number,
     offset: number = 0
   ): void {
+    DataParser.ensureAvailable(data, offset, 4);
     data[offset] = (value >> 24) & 0xff;
     data[offset + 1] = (value >> 16) & 0xff;
     data[offset + 2] = (value >> 8) & 0xff;
@@ -135,6 +161,7 @@ export class DataParser {
     offset: number = 0,
     maxLength?: number
   ): string {
+    DataParser.ensureAvailable(data, offset, 1);
     const end = maxLength
       ? Math.min(offset + maxLength, data.length)
       : data.length;
@@ -153,13 +180,28 @@ export class DataParser {
     offset: number = 0,
     maxLength?: number
   ): void {
-    const end = maxLength
-      ? Math.min(offset + maxLength - 1, data.length - 1)
-      : data.length - 1;
-    let i = offset;
-    for (; i < end && i - offset < value.length; i++) {
-      data[i] = value.charCodeAt(i - offset);
+    DataParser.ensureAvailable(data, offset, 1);
+    const available = data.length - offset;
+    if (maxLength !== undefined && maxLength < 0) {
+      throw new RangeError('CString maxLength must be non-negative');
     }
-    data[i] = 0; // Null terminator
+    const limit =
+      maxLength !== undefined ? Math.min(maxLength, available) : available;
+    if (limit <= 0) {
+      throw new RangeError('CString region must be at least 1 byte to include a terminator');
+    }
+
+    const charsToWrite = Math.min(value.length, limit - 1);
+    let i = 0;
+    for (; i < charsToWrite; i++) {
+      data[offset + i] = value.charCodeAt(i);
+    }
+
+    data[offset + i] = 0; // Null terminator
+
+    // Clear any remaining space inside the region to avoid leaking stale data
+    for (let j = i + 1; j < limit; j++) {
+      data[offset + j] = 0;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add bounds checking to the DataParser read/write helpers
- tighten CString writing to validate capacity and clear trailing bytes
- extend DataParser tests to cover the new guard rails

## Testing
- timeout 60 npm test --workspace=@m68k/memory

------
https://chatgpt.com/codex/tasks/task_e_68e052922b8c833199e481618b24ac4a