### PR TITLE
Avoid mutating dispatched memory access events

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -419,8 +419,10 @@ class SystemImpl implements System {
     listeners: Set<MemoryAccessCallback>,
     event: MemoryAccessEvent
   ): void {
-    const payload = event as MemoryAccessEvent & { sequence?: number };
-    payload.sequence = ++this._memSequence;
+    const payload: MemoryAccessEvent = {
+      ...event,
+      sequence: ++this._memSequence,
+    };
 
     if (TRACE_ENABLED) {
       this._maybeTraceMemoryEvent(payload);


### PR DESCRIPTION
## Summary
- avoid mutating memory access events when notifying listeners so hooks receive a fresh payload

## Testing
- timeout 60 npm run typecheck *(fails: TypeScript cannot resolve @m68k/common workspace module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2efd21c988331931723d76bfe42fa