### PR TITLE
refactor: share 24-bit mask helper

### DIFF
--- a/packages/core/src/address-utils.ts
+++ b/packages/core/src/address-utils.ts
@@ -1,0 +1,1 @@
+export const mask24 = (value: number): number => (value >>> 0) & 0x00ffffff;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ import type {
 } from './types.js';
 import { M68kRegister } from '@m68k/common';
 import { MusashiWrapper, getModule } from './musashi-wrapper.js';
+import { mask24 } from './address-utils.js';
 
 // Re-export types
 export type {
@@ -41,7 +42,7 @@ export type {
 
 // --- Private Implementation ---
 
-const normalizeTraceAddress = (value: number): number => (value >>> 0) & 0x00ffffff;
+const normalizeTraceAddress = mask24;
 const formatTraceHex = (value: number): string => `0x${(value >>> 0).toString(16)}`;
 
 const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -5,8 +5,7 @@ type EmscriptenBuffer = number;
 type EmscriptenFunction = number;
 import { M68kRegister } from '@m68k/common';
 import type { MemoryLayout, MemoryTraceSource } from './types.js';
-
-const mask24 = (value: number): number => (value >>> 0) & 0x00ffffff;
+import { mask24 } from './address-utils.js';
 
 type RuntimeTag = 'node' | 'browser';
 


### PR DESCRIPTION
## Summary
- extract a shared 24-bit address masking helper to remove duplicate logic between the core facade and Musashi wrapper

## Testing
- timeout 60 npm test --workspace=@m68k/core *(fails: Cannot find module '@m68k/common' in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4356685d08331a1c44649b82fdaa9