### PR TITLE
Ship Perfetto bundle by default and add packaged e2e test

### DIFF
--- a/npm-package/scripts/generate-wrapper.js
+++ b/npm-package/scripts/generate-wrapper.js
@@ -717,19 +717,9 @@ if (nodeWasmMapIn) {
 
 const perfLoaderOut = path.join(distDir, 'musashi-perfetto-loader.mjs');
 const perfWasmOut = path.join(distDir, 'musashi-perfetto.wasm');
-if (process.env.ENABLE_PERFETTO === '1') {
-  const perfLoaderSource = fs
-    .readFileSync(nodeJsIn, 'utf8')
-    .replace(/musashi-node\.out\.wasm/g, 'musashi-perfetto.wasm');
-  fs.writeFileSync(perfLoaderOut, perfLoaderSource);
-  fs.copyFileSync(nodeWasmIn, perfWasmOut);
-} else {
-  [perfLoaderOut, perfWasmOut].forEach(target => {
-    if (fs.existsSync(target)) {
-      fs.rmSync(target);
-    }
-  });
-}
+const perfLoaderSource = nodeJsSource.replace(/musashi-node\.out\.wasm/g, 'musashi-perfetto.wasm');
+fs.writeFileSync(perfLoaderOut, perfLoaderSource);
+fs.copyFileSync(nodeWasmIn, perfWasmOut);
 
 const browserJsIn = browserJsCandidates.find(p => fs.existsSync(p));
 const browserWasmIn = browserWasmCandidates.find(p => fs.existsSync(p));

--- a/npm-package/test/package-consumer.mjs
+++ b/npm-package/test/package-consumer.mjs
@@ -1,0 +1,113 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+
+const pkgDir = new URL('..', import.meta.url);
+
+const run = (cmd, args, options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: ['ignore', 'pipe', 'inherit'],
+      ...options,
+    });
+
+    let stdout = '';
+    if (child.stdout) {
+      child.stdout.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+    }
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        reject(new Error(`${cmd} ${args.join(' ')} exited with ${code}`));
+      }
+    });
+  });
+
+const pkgPath = (relative) => new URL(relative, pkgDir).pathname;
+
+const ensurePerfBuild = async () => {
+  await run(
+    'npm',
+    ['run', 'build'],
+    {
+      cwd: pkgPath('.'),
+      env: { ...process.env, ENABLE_PERFETTO: '1' },
+    }
+  );
+};
+
+const packPackage = async () => {
+  const output = await run(
+    'npm',
+    ['pack', '--json'],
+    { cwd: pkgPath('.') }
+  );
+  const entries = JSON.parse(output);
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error(`Unexpected npm pack output: ${output}`);
+  }
+  return join(pkgPath('.'), entries[0].filename);
+};
+
+const runConsumerTest = async (tarballPath) => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'musashi-perf-consumer-'));
+  const cleanup = async () => {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  };
+
+  try {
+    await run('npm', ['init', '-y'], { cwd: tempDir });
+    await run('npm', ['install', tarballPath], { cwd: tempDir });
+
+    const testScript = `
+      import { createSystem } from 'musashi-wasm/core';
+      const rom = new Uint8Array(0x2000);
+      rom.set([0x00,0x10,0x00,0x00, 0x00,0x00,0x04,0x00], 0);
+      rom.set([0x4e,0x71,0x4e,0x71,0x4e,0x75], 0x400);
+      const system = await createSystem({ rom, ramSize: 0x2000 });
+      if (!system.tracer.isAvailable()) {
+        throw new Error('Perfetto tracer not available in packaged module');
+      }
+      system.tracer.start({ instructions: true });
+      system.run(4);
+      const trace = system.tracer.stop();
+      if (!(trace instanceof Uint8Array) || trace.length === 0) {
+        throw new Error('Perfetto trace missing or empty');
+      }
+      system.cleanup();
+      console.log('TRACE_LENGTH=' + trace.length);
+    `;
+
+    const scriptFile = join(tempDir, `verify-${randomUUID()}.mjs`);
+    await writeFile(scriptFile, testScript, 'utf8');
+    const output = await run('node', [scriptFile], { cwd: tempDir });
+    if (!/TRACE_LENGTH=\d+/.test(output)) {
+      throw new Error(`Unexpected verification output: ${output}`);
+    }
+  } finally {
+    await cleanup();
+  }
+};
+
+const main = async () => {
+  await ensurePerfBuild();
+  const tarball = await packPackage();
+  try {
+    await runConsumerTest(tarball);
+  } finally {
+    await rm(tarball, { force: true }).catch(() => {});
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/run-tests-ci.sh
+++ b/run-tests-ci.sh
@@ -71,4 +71,15 @@ if ! timeout 60 npm --prefix npm-package run test:browser; then
   exit $rc
 fi
 
+echo "Validating packaged npm tarball exposes Perfetto tracing..."
+if ! timeout 120 node npm-package/test/package-consumer.mjs; then
+  rc=$?
+  if [[ $rc -eq 124 ]]; then
+    echo "npm-package consumer verification timed out after 120s" >&2
+  else
+    echo "npm-package consumer verification failed with exit code ${rc}" >&2
+  fi
+  exit $rc
+fi
+
 echo "All tests completed"


### PR DESCRIPTION
## Summary\n- update generate-wrapper to always emit musashi-perfetto loader/wasm when perf exports exist\n- add npm-package/test/package-consumer.mjs which packs the tarball, installs it, and asserts tracer availability\n- run the consumer script from run-tests-ci.sh\n\n## Testing\n- ENABLE_PERFETTO=1 npm --prefix npm-package run build\n- npm --prefix npm-package run test:browser\n- node npm-package/test/package-consumer.mjs\n- timeout 60 npm test --workspace=@m68k/core