### PR TITLE
Fix Perfetto tracing in browser builds

### DIFF
--- a/npm-package/lib/memory/index.d.ts
+++ b/npm-package/lib/memory/index.d.ts
@@ -34,6 +34,8 @@ export declare class MemoryArray<T> {
 	private readonly parser;
 	constructor(system: SystemMemoryIO, baseAddress: number, stride: number, // The size of each element in bytes.
 	parser: Parser<T>);
+	private ensureNonNegativeInteger;
+	private resolveAddress;
 	/** Reads and parses the element at the given index. */
 	at(index: number): T;
 	/** Writes raw bytes to the element at the given index. */
@@ -45,6 +47,7 @@ export declare class MemoryArray<T> {
  * Helper utilities for parsing common data types from byte arrays.
  */
 export declare class DataParser {
+	private static ensureAvailable;
 	/** Reads a big-endian 16-bit unsigned integer. */
 	static readUint16BE(data: Uint8Array, offset?: number): number;
 	/** Reads a big-endian 32-bit unsigned integer. */


### PR DESCRIPTION
## Summary
- add a Playwright regression that exercises Perfetto tracing in a real browser without env overrides
- load the Perfetto module in any runtime unless disabled and resolve it from multiple locations
- package the universal Perfetto loader/wasm so the published perf.mjs works in browsers

## Testing
- timeout 60 npm --prefix npm-package run test:browser
- timeout 30 node npm-package/test/integration.mjs
- timeout 120 node npm-package/test/package-consumer.mjs
- timeout 60 npm run test:ci --workspace=@m68k/core
- timeout 60 npm run test:ci --workspace=@m68k/memory
