### PR TITLE
Reuse staged perf loader when universal artifacts unavailable

### DIFF
--- a/npm-package/scripts/generate-wrapper.js
+++ b/npm-package/scripts/generate-wrapper.js
@@ -737,7 +737,6 @@ const universalWasmMapCandidates = [
 const universalJsIn = universalJsCandidates.find(p => fs.existsSync(p));
 const universalWasmIn = universalWasmCandidates.find(p => fs.existsSync(p));
 const universalWasmMapIn = universalWasmMapCandidates.find(p => fs.existsSync(p));
-
 const perfLoaderOut = path.join(distDir, 'musashi-perfetto-loader.mjs');
 const perfWasmOut = path.join(distDir, 'musashi-perfetto.wasm');
 const perfWasmMapOut = path.join(distDir, 'musashi-perfetto.wasm.map');
@@ -760,7 +759,15 @@ if (universalJsIn && universalWasmIn) {
     fs.rmSync(perfWasmMapOut);
   }
 } else {
-  throw new Error('Missing universal WebAssembly build artifacts (musashi-universal.out.* or musashi.out.*). Run `./build.sh` with ENABLE_PERFETTO=1 before packaging.');
+  if (
+    !fs.existsSync(perfLoaderOut) ||
+    !fs.existsSync(perfWasmOut) ||
+    !fs.readFileSync(perfLoaderOut, 'utf8').includes(perfettoSymbol)
+  ) {
+    throw new Error(
+      'Missing universal WebAssembly build artifacts (musashi-universal.out.* or musashi.out.*). Run `./build.sh` with ENABLE_PERFETTO=1 before packaging.'
+    );
+  }
 }
 
 const browserJsIn = browserJsCandidates.find(p => fs.existsSync(p));


### PR DESCRIPTION
## Summary
- fall back to the already staged musashi-perfetto loader/wasm if musashi-universal artifacts are not present
- keep validating that the staged loader still includes the perfetto exports before proceeding

## Testing
- timeout 60 npm --prefix npm-package run test:browser
- timeout 30 node npm-package/test/integration.mjs
- timeout 120 node npm-package/test/package-consumer.mjs
