### PR TITLE
Use CI perf artifacts when regenerating loader

### DIFF
--- a/npm-package/scripts/generate-wrapper.js
+++ b/npm-package/scripts/generate-wrapper.js
@@ -715,21 +715,30 @@ if (nodeWasmMapIn) {
   });
 }
 
+const perfArtifactDir = path.join(repoRootDir, 'ci-artifacts', 'wasm-perfetto-modules');
+const standardArtifactDir = path.join(repoRootDir, 'ci-artifacts', 'wasm-modules');
+
 const universalJsCandidates = [
   path.join(rootDir, 'musashi-universal.out.mjs'),
+  path.join(perfArtifactDir, 'musashi-universal.out.mjs'),
   path.join(altRootDir, 'musashi-universal.out.mjs'),
+  path.join(standardArtifactDir, 'musashi-universal.out.mjs'),
   path.join(rootDir, 'musashi.out.mjs'),
   path.join(altRootDir, 'musashi.out.mjs')
 ];
 const universalWasmCandidates = [
   path.join(rootDir, 'musashi-universal.out.wasm'),
+  path.join(perfArtifactDir, 'musashi-universal.out.wasm'),
   path.join(altRootDir, 'musashi-universal.out.wasm'),
+  path.join(standardArtifactDir, 'musashi-universal.out.wasm'),
   path.join(rootDir, 'musashi.out.wasm'),
   path.join(altRootDir, 'musashi.out.wasm')
 ];
 const universalWasmMapCandidates = [
   path.join(rootDir, 'musashi-universal.out.wasm.map'),
+  path.join(perfArtifactDir, 'musashi-universal.out.wasm.map'),
   path.join(altRootDir, 'musashi-universal.out.wasm.map'),
+  path.join(standardArtifactDir, 'musashi-universal.out.wasm.map'),
   path.join(rootDir, 'musashi.out.wasm.map'),
   path.join(altRootDir, 'musashi.out.wasm.map')
 ];


### PR DESCRIPTION
## Summary
- include ci-artifacts/wasm-perfetto-modules paths when searching for universal perf builds during npm-package wrapper generation
- keep existing fallbacks for local builds and reuse pre-staged loader if nothing suitable is found

## Testing
- timeout 60 npm --prefix npm-package run test:browser
- timeout 30 node npm-package/test/integration.mjs
- timeout 120 node npm-package/test/package-consumer.mjs
