### PR TITLE
Add Perfetto summary track for root call

### DIFF
--- a/m68k_perfetto.cc
+++ b/m68k_perfetto.cc
@@ -188,12 +188,14 @@ M68kPerfettoTracer::M68kPerfettoTracer(const std::string& process_name)
     : flow_enabled_(false)
     , memory_enabled_(false)
     , instruction_enabled_(false)
+    , summary_slice_open_(false)
     , total_instructions_(0)
     , total_memory_accesses_(0) {
     
     trace_builder_ = std::make_unique<retrobus::PerfettoTraceBuilder>(process_name);
     
     /* Create tracks for different event types */
+    summary_track_id_ = trace_builder_->add_thread("Summary");
     cpu_thread_track_id_ = trace_builder_->add_thread("Flow");
     jumps_thread_track_id_ = trace_builder_->add_thread("Jumps");
     instr_thread_track_id_ = trace_builder_->add_thread("Instructions");
@@ -209,17 +211,48 @@ M68kPerfettoTracer::~M68kPerfettoTracer() {
 
 void M68kPerfettoTracer::cleanup_unclosed_slices() {
     /* Close any remaining open slices to prevent "Did not end" in Perfetto UI */
-    if (!call_stack_.empty()) {
-        /* Get a reasonable end timestamp (current cycles + small offset) */
+    if (!call_stack_.empty() || summary_slice_open_) {
         uint64_t cleanup_timestamp_ns = cycles_to_nanoseconds(999999);  /* ~125ms at 8MHz */
-        
+
         /* Close all remaining slices in reverse order (LIFO) */
         while (!call_stack_.empty()) {
             trace_builder_->end_slice(cpu_thread_track_id_, cleanup_timestamp_ns);
             call_stack_.pop_back();
             cleanup_timestamp_ns += 1000;  /* Small time increment between closes */
         }
+
+        if (summary_slice_open_) {
+            trace_builder_->end_slice(summary_track_id_, cleanup_timestamp_ns);
+            summary_slice_open_ = false;
+            summary_slice_name_.clear();
+        }
     }
+}
+
+void M68kPerfettoTracer::enable_flow_tracing(bool enable) {
+    if (!enable) {
+        cleanup_unclosed_slices();
+    }
+    flow_enabled_ = enable;
+}
+
+void M68kPerfettoTracer::begin_summary_slice(uint64_t timestamp_ns, uint32_t dest_pc) {
+    if (summary_slice_open_) {
+        return;
+    }
+
+    const char* func_name = get_function_name(dest_pc);
+    summary_slice_name_ = func_name ? std::string(func_name)
+                                    : (std::string("call_") + format_hex(dest_pc));
+
+    auto summary_event = trace_builder_->begin_slice(summary_track_id_, summary_slice_name_, timestamp_ns)
+        .add_pointer("target_pc", dest_pc);
+
+    if (func_name) {
+        summary_event.add_annotation("func_name", func_name);
+    }
+
+    summary_slice_open_ = true;
 }
 
 int M68kPerfettoTracer::handle_flow_event(m68k_trace_flow_type type, uint32_t source_pc, 
@@ -234,6 +267,8 @@ int M68kPerfettoTracer::handle_flow_event(m68k_trace_flow_type type, uint32_t so
 
     switch (type) {
         case M68K_TRACE_FLOW_CALL: {
+            const bool call_stack_was_empty = call_stack_.empty();
+
             /* Begin a slice for the call and track it on call stack */
             /* Use registered function name if available */
             const char* func_name = get_function_name(dest_pc);
@@ -276,6 +311,10 @@ int M68kPerfettoTracer::handle_flow_event(m68k_trace_flow_type type, uint32_t so
             flow_state.source_pc = source_pc;
             flow_state.flow_name = std::string("call_") + format_hex(dest_pc);
             call_stack_.push_back(flow_state);
+
+            if (call_stack_was_empty) {
+                begin_summary_slice(timestamp_ns, dest_pc);
+            }
             break;
         }
 
@@ -287,6 +326,12 @@ int M68kPerfettoTracer::handle_flow_event(m68k_trace_flow_type type, uint32_t so
                 /* End the slice with proper timestamp */
                 trace_builder_->end_slice(cpu_thread_track_id_, timestamp_ns);
                 call_stack_.pop_back();
+
+                if (call_stack_.empty() && summary_slice_open_) {
+                    trace_builder_->end_slice(summary_track_id_, timestamp_ns);
+                    summary_slice_open_ = false;
+                    summary_slice_name_.clear();
+                }
             } else {
                 /* Return without matching call - can happen when starting mid-execution */
             }

--- a/m68k_perfetto.h
+++ b/m68k_perfetto.h
@@ -74,7 +74,7 @@ public:
     M68kPerfettoTracer& operator=(M68kPerfettoTracer&&) = delete;
 
     /* Configuration */
-    void enable_flow_tracing(bool enable) { flow_enabled_ = enable; }
+    void enable_flow_tracing(bool enable);
     void enable_memory_tracing(bool enable) { memory_enabled_ = enable; }
     void enable_instruction_tracing(bool enable) { instruction_enabled_ = enable; }
     
@@ -100,6 +100,7 @@ public:
 private:
     /* Trace builder and track IDs */
     std::unique_ptr<retrobus::PerfettoTraceBuilder> trace_builder_;
+    uint64_t summary_track_id_;
     uint64_t cpu_thread_track_id_;
     uint64_t jumps_thread_track_id_;
     uint64_t instr_thread_track_id_;
@@ -111,6 +112,7 @@ private:
     bool flow_enabled_;
     bool memory_enabled_;
     bool instruction_enabled_;
+    bool summary_slice_open_;
 
     /* Internal state for flow tracking */
     struct FlowState {
@@ -119,6 +121,7 @@ private:
         std::string flow_name;
     };
     std::vector<FlowState> call_stack_;
+    std::string summary_slice_name_;
 
     /* Performance counters */
     uint64_t total_instructions_;
@@ -127,6 +130,7 @@ private:
     /* Utility functions */
     std::string format_hex(uint32_t value) const;
     uint64_t cycles_to_nanoseconds(uint64_t cycles) const;
+    void begin_summary_slice(uint64_t timestamp_ns, uint32_t dest_pc);
 };
 
 } /* namespace m68k_perfetto */

--- a/tests/test_perfetto.cpp
+++ b/tests/test_perfetto.cpp
@@ -12,6 +12,10 @@
 #include <vector>
 #include <set>
 
+#ifdef ENABLE_PERFETTO
+#include <perfetto.pb.h>
+#endif
+
 /* Forward declarations for myfunc.cc wrapper functions */
 extern "C" {
     /* Perfetto wrapper functions from myfunc.cc */
@@ -350,6 +354,91 @@ TEST_F(PerfettoTest, FlowTracingEmitsDuplicateCallEventsForJsrs) {
 
     m68k_set_trace_flow_callback(nullptr);
     m68k_trace_set_flow_enabled(0);
+}
+
+TEST_F(PerfettoTest, FlowTracingAddsSummarySlice) {
+    if (::perfetto_init("M68K_Summary_Test") != 0) {
+        GTEST_SKIP() << "Perfetto not available, skipping summary slice test";
+    }
+
+    ::perfetto_enable_flow(1);
+    ::register_function_name(0x500, "root_call");
+
+    uint32_t pc = 0x400;
+    /* JSR to root_call */
+    write_word(pc, 0x4EB9); pc += 2;
+    write_long(pc, 0x00000500); pc += 4;
+    /* STOP */
+    write_word(pc, 0x4E72); pc += 2;
+    write_word(pc, 0x2700); pc += 2;
+
+    /* Subroutine implementation */
+    write_word(0x500, 0x4E71); /* NOP */
+    write_word(0x502, 0x4E75); /* RTS */
+
+    m68k_pulse_reset();
+    m68k_execute(200);
+
+    uint8_t* trace_data = nullptr;
+    size_t trace_size = 0;
+    ASSERT_EQ(::perfetto_export_trace(&trace_data, &trace_size), 0);
+
+#ifdef ENABLE_PERFETTO
+    ASSERT_NE(trace_data, nullptr);
+
+    perfetto::protos::Trace trace;
+    ASSERT_TRUE(trace.ParseFromArray(trace_data, static_cast<int>(trace_size)));
+
+    bool summary_track_found = false;
+    uint64_t summary_uuid = 0;
+
+    for (const auto& packet : trace.packet()) {
+        if (packet.has_track_descriptor()) {
+            const auto& descriptor = packet.track_descriptor();
+            if (descriptor.has_name() && descriptor.name() == "Summary") {
+                summary_track_found = true;
+                summary_uuid = descriptor.uuid();
+                break;
+            }
+        }
+    }
+
+    EXPECT_TRUE(summary_track_found) << "Summary track missing from Perfetto trace";
+
+    int summary_slice_begins = 0;
+    int summary_slice_ends = 0;
+    std::string summary_slice_name;
+
+    if (summary_track_found) {
+        for (const auto& packet : trace.packet()) {
+            if (!packet.has_track_event()) {
+                continue;
+            }
+            const auto& event = packet.track_event();
+            if (event.track_uuid() != summary_uuid) {
+                continue;
+            }
+
+            if (event.type() == perfetto::protos::TrackEvent::TYPE_SLICE_BEGIN) {
+                summary_slice_begins++;
+                summary_slice_name = event.name();
+            } else if (event.type() == perfetto::protos::TrackEvent::TYPE_SLICE_END) {
+                summary_slice_ends++;
+            }
+        }
+    }
+
+    EXPECT_EQ(summary_slice_begins, 1) << "Expected exactly one summary slice begin event";
+    EXPECT_EQ(summary_slice_ends, 1) << "Expected exactly one summary slice end event";
+    EXPECT_EQ(summary_slice_name, "root_call")
+        << "Summary slice should resolve to registered function name";
+#endif
+
+    if (trace_data) {
+        ::perfetto_free_trace_data(trace_data);
+    }
+
+    ::perfetto_enable_flow(0);
 }
 
 /* ======================================================================== */


### PR DESCRIPTION
## Summary
- add a dedicated Perfetto "Summary" track that spans the first-to-last call in a trace
- close the summary slice automatically on flow disable/cleanup
- add a regression test that exports and inspects the trace protobuf to verify the summary slice resolves to function symbols

## Testing
- timeout 60 ctest --output-on-failure -R FlowTracingAddsSummarySlice
- timeout 60 ctest --output-on-failure -R PerfettoTest
- timeout 60 env ENABLE_PERFETTO=1 npm --prefix npm-package run build
- timeout 30 node npm-package/test/integration.mjs
- timeout 60 npm --prefix npm-package run test:browser
- bash run-tests-ci.sh (times out at packaged consumer step under CLI limit)