### PR TITLE
Add top-level summary slice on Flow track

### DIFF
--- a/m68k_perfetto.h
+++ b/m68k_perfetto.h
@@ -74,7 +74,7 @@ public:
     M68kPerfettoTracer& operator=(M68kPerfettoTracer&&) = delete;
 
     /* Configuration */
-    void enable_flow_tracing(bool enable) { flow_enabled_ = enable; }
+    void enable_flow_tracing(bool enable);
     void enable_memory_tracing(bool enable) { memory_enabled_ = enable; }
     void enable_instruction_tracing(bool enable) { instruction_enabled_ = enable; }
     
@@ -111,6 +111,7 @@ private:
     bool flow_enabled_;
     bool memory_enabled_;
     bool instruction_enabled_;
+    bool summary_slice_open_;
 
     /* Internal state for flow tracking */
     struct FlowState {
@@ -119,6 +120,7 @@ private:
         std::string flow_name;
     };
     std::vector<FlowState> call_stack_;
+    std::string summary_slice_name_;
 
     /* Performance counters */
     uint64_t total_instructions_;
@@ -127,6 +129,7 @@ private:
     /* Utility functions */
     std::string format_hex(uint32_t value) const;
     uint64_t cycles_to_nanoseconds(uint64_t cycles) const;
+    void begin_summary_slice(uint64_t timestamp_ns, uint32_t dest_pc);
 };
 
 } /* namespace m68k_perfetto */


### PR DESCRIPTION
## Summary
- open a root Perfetto slice on the Flow thread when the first CALL arrives and close it after the last RETURN
- annotate the summary slice so downstream tooling can distinguish it from regular calls
- add a regression test that exports the trace protobuf, verifies nesting on the Flow track, and checks symbol resolution

## Testing
- timeout 60 ctest --output-on-failure -R FlowTracingAddsTopLevelSummarySlice
- timeout 60 ctest --output-on-failure -R PerfettoTest
- timeout 60 env ENABLE_PERFETTO=1 npm --prefix npm-package run build
- timeout 30 node npm-package/test/integration.mjs
- timeout 60 npm --prefix npm-package run test:browser
- bash run-tests-ci.sh (times out at packaged consumer step under CLI limit)