### PR TITLE
Add optional instruction register annotations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -106,6 +106,7 @@ if [[ "$ENABLE_PERFETTO_FLAG" == "1" ]]; then
     _m68k_perfetto_destroy
     _m68k_perfetto_enable_flow
     _m68k_perfetto_enable_instructions
+    _m68k_perfetto_enable_instruction_registers
     _m68k_perfetto_enable_memory
     _m68k_perfetto_export_trace
     _m68k_perfetto_free_trace_data

--- a/m68k_perfetto.h
+++ b/m68k_perfetto.h
@@ -41,6 +41,7 @@ void m68k_perfetto_cleanup_slices(void);
 void m68k_perfetto_enable_flow(int enable);
 void m68k_perfetto_enable_memory(int enable);
 void m68k_perfetto_enable_instructions(int enable);
+void m68k_perfetto_enable_instruction_registers(int enable);
 
 /* Export trace data (critical for WASM) */
 int m68k_perfetto_export_trace(uint8_t** data_out, size_t* size_out);
@@ -76,7 +77,8 @@ public:
     /* Configuration */
     void enable_flow_tracing(bool enable);
     void enable_memory_tracing(bool enable) { memory_enabled_ = enable; }
-    void enable_instruction_tracing(bool enable) { instruction_enabled_ = enable; }
+    void enable_instruction_tracing(bool enable);
+    void enable_instruction_registers(bool enable) { instruction_regs_enabled_ = enable; }
     
     /* Force cleanup of unclosed slices */
     void cleanup_unclosed_slices();
@@ -112,6 +114,7 @@ private:
     bool memory_enabled_;
     bool instruction_enabled_;
     bool summary_slice_open_;
+    bool instruction_regs_enabled_;
 
     /* Internal state for flow tracking */
     struct FlowState {
@@ -152,6 +155,7 @@ static inline void m68k_perfetto_destroy(void) {}
 static inline void m68k_perfetto_enable_flow(int enable) { (void)enable; }
 static inline void m68k_perfetto_enable_memory(int enable) { (void)enable; }
 static inline void m68k_perfetto_enable_instructions(int enable) { (void)enable; }
+static inline void m68k_perfetto_enable_instruction_registers(int enable) { (void)enable; }
 static inline int m68k_perfetto_export_trace(uint8_t** data_out, size_t* size_out) { 
     (void)data_out; (void)size_out; return -1; 
 }

--- a/myfunc.cc
+++ b/myfunc.cc
@@ -862,6 +862,12 @@ extern "C" {
       printf("perfetto_enable_instructions: %d\n", enable);
     m68k_perfetto_enable_instructions(enable);
   }
+
+  void perfetto_enable_instruction_registers(int enable) {
+    if (_enable_printf_logging)
+      printf("perfetto_enable_instruction_registers: %d\n", enable);
+    m68k_perfetto_enable_instruction_registers(enable);
+  }
   
   /* Export trace data (critical for WASM) */
   int perfetto_export_trace(uint8_t** data_out, size_t* size_out) {

--- a/npm-package/scripts/generate-wrapper.js
+++ b/npm-package/scripts/generate-wrapper.js
@@ -585,6 +585,10 @@ class MusashiPerfetto {
   enableInstructionTracing(enable) {
     this.module._m68k_perfetto_enable_instructions(enable ? 1 : 0);
   }
+
+  enableInstructionRegisters(enable) {
+    this.module._m68k_perfetto_enable_instruction_registers?.(enable ? 1 : 0);
+  }
   
   enableMemoryTracing(enable) {
     this.module._m68k_perfetto_enable_memory(enable ? 1 : 0);
@@ -912,6 +916,7 @@ export class MusashiPerfetto {
   // Perfetto-specific methods
   enableFlowTracing(enable) { this.module._m68k_perfetto_enable_flow(enable ? 1 : 0); }
   enableInstructionTracing(enable) { this.module._m68k_perfetto_enable_instructions(enable ? 1 : 0); }
+  enableInstructionRegisters(enable) { this.module._m68k_perfetto_enable_instruction_registers?.(enable ? 1 : 0); }
   enableMemoryTracing(enable) { this.module._m68k_perfetto_enable_memory(enable ? 1 : 0); }
   enableInterruptTracing(enable) { this.module._m68k_perfetto_enable_interrupts(enable ? 1 : 0); }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -166,6 +166,9 @@ class TracerImpl implements Tracer {
     this._musashi.perfettoEnableFlow(!!config.flow);
     this._musashi.perfettoEnableMemory(!!config.memory);
     this._musashi.perfettoEnableInstructions(!!config.instructions);
+    this._musashi.perfettoEnableInstructionRegisters(
+      !!config.instructions && !!config.instructionsRegisters
+    );
 
     this._active = true;
   }

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -100,6 +100,7 @@ export interface MusashiEmscriptenModule {
   _m68k_perfetto_enable_flow?(enable: number): void;
   _m68k_perfetto_enable_memory?(enable: number): void;
   _m68k_perfetto_enable_instructions?(enable: number): void;
+  _m68k_perfetto_enable_instruction_registers?(enable: number): void;
   _m68k_perfetto_export_trace?(
     data_out: EmscriptenBuffer,
     size_out: EmscriptenBuffer
@@ -726,6 +727,10 @@ export class MusashiWrapper {
 
   perfettoEnableInstructions(enable: boolean) {
     this._module._m68k_perfetto_enable_instructions?.(enable ? 1 : 0);
+  }
+
+  perfettoEnableInstructionRegisters(enable: boolean) {
+    this._module._m68k_perfetto_enable_instruction_registers?.(enable ? 1 : 0);
   }
 
   traceEnable(enable: boolean) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,6 +64,11 @@ export interface SystemConfig {
 export interface TraceConfig {
   /** Trace instruction execution slices. Defaults to false. */
   instructions?: boolean;
+  /**
+   * Include full D/A register snapshots on every instruction slice.
+   * Ignored unless `instructions` tracing is enabled. Defaults to false.
+   */
+  instructionsRegisters?: boolean;
   /** Trace function calls, returns, and jumps. Defaults to false. */
   flow?: boolean;
   /** Trace memory write operations. Defaults to false. */


### PR DESCRIPTION
## Summary
- add an opt-in Perfetto flag to snapshot D/A registers alongside instruction slices
- expose the flag through the musashi C API and JS tracer config (TraceConfig.instructionsRegisters)
- add C++ regression tests to guard nested call flow and verify register annotations

## Testing
- cmake -B build-perfetto -S . -DENABLE_PERFETTO=ON -DBUILD_TESTS=ON
- cmake --build build-perfetto --target test_perfetto
- timeout 60 ctest --output-on-failure -R PerfettoTest
- timeout 60 env ENABLE_PERFETTO=1 npm --prefix npm-package run build
- timeout 30 node npm-package/test/integration.mjs
- timeout 60 npm --prefix npm-package run test:browser
- bash run-tests-ci.sh