### PR TITLE
Guard instruction register tracing before Perfetto init

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,6 +155,18 @@ class TracerImpl implements Tracer {
       throw new Error('A tracing session is already active.');
     }
 
+    const wantsInstructionRegisters =
+      !!config.instructions && !!config.instructionsRegisters;
+
+    if (
+      wantsInstructionRegisters &&
+      !this._musashi.hasPerfettoInstructionRegisterSupport()
+    ) {
+      throw new Error(
+        'Perfetto instruction register tracing is not available in this Wasm build.'
+      );
+    }
+
     if (this._musashi.perfettoInit('m68k-ts') !== 0) {
       throw new Error('Failed to initialize Perfetto tracing session.');
     }
@@ -167,7 +179,7 @@ class TracerImpl implements Tracer {
     this._musashi.perfettoEnableMemory(!!config.memory);
     this._musashi.perfettoEnableInstructions(!!config.instructions);
     this._musashi.perfettoEnableInstructionRegisters(
-      !!config.instructions && !!config.instructionsRegisters
+      wantsInstructionRegisters
     );
 
     this._active = true;

--- a/packages/core/src/musashi-wrapper.perfetto-registers.test.ts
+++ b/packages/core/src/musashi-wrapper.perfetto-registers.test.ts
@@ -1,0 +1,42 @@
+import { jest } from '@jest/globals';
+import { MusashiWrapper } from './musashi-wrapper.js';
+
+const createStubModule = (
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> => ({
+  HEAPU8: new Uint8Array(0),
+  HEAP32: new Int32Array(0),
+  HEAPU32: new Uint32Array(0),
+  _m68k_set_trace_mem_callback: () => {},
+  _m68k_trace_enable: () => {},
+  _m68k_trace_set_mem_enabled: () => {},
+  _malloc: () => 0,
+  _free: () => {},
+  ...overrides,
+});
+
+describe('MusashiWrapper.perfettoEnableInstructionRegisters', () => {
+  it('throws when enabling without wasm support', () => {
+    const wrapper = new MusashiWrapper(createStubModule() as any);
+
+    expect(() => wrapper.perfettoEnableInstructionRegisters(false)).not.toThrow();
+    expect(() => wrapper.perfettoEnableInstructionRegisters(true)).toThrow(
+      /instruction register tracing is not available/i
+    );
+  });
+
+  it('invokes the wasm export when available', () => {
+    const enableMock = jest.fn();
+    const wrapper = new MusashiWrapper(
+      createStubModule({
+        _m68k_perfetto_enable_instruction_registers: enableMock,
+      }) as any
+    );
+
+    wrapper.perfettoEnableInstructionRegisters(true);
+    wrapper.perfettoEnableInstructionRegisters(false);
+
+    expect(enableMock).toHaveBeenNthCalledWith(1, 1);
+    expect(enableMock).toHaveBeenNthCalledWith(2, 0);
+  });
+});

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -680,6 +680,13 @@ export class MusashiWrapper {
     return typeof this._module._m68k_perfetto_init === 'function';
   }
 
+  hasPerfettoInstructionRegisterSupport(): boolean {
+    return (
+      typeof this._module._m68k_perfetto_enable_instruction_registers ===
+      'function'
+    );
+  }
+
   private withHeapString<T>(value: string, fn: (ptr: number) => T): T {
     const malloc = this._module._malloc;
     const free = this._module._free;
@@ -730,7 +737,16 @@ export class MusashiWrapper {
   }
 
   perfettoEnableInstructionRegisters(enable: boolean) {
-    this._module._m68k_perfetto_enable_instruction_registers?.(enable ? 1 : 0);
+    const fn = this._module._m68k_perfetto_enable_instruction_registers;
+    if (!fn) {
+      if (enable) {
+        throw new Error(
+          'Perfetto instruction register tracing is not available in this Wasm build.'
+        );
+      }
+      return;
+    }
+    fn(enable ? 1 : 0);
   }
 
   traceEnable(enable: boolean) {

--- a/packages/core/src/tracer-instruction-registers.guard.test.ts
+++ b/packages/core/src/tracer-instruction-registers.guard.test.ts
@@ -1,0 +1,61 @@
+import { jest } from '@jest/globals';
+import { createSystem } from './index.js';
+
+const writeLongBE = (buffer: Uint8Array, offset: number, value: number) => {
+  buffer[offset] = (value >>> 24) & 0xff;
+  buffer[offset + 1] = (value >>> 16) & 0xff;
+  buffer[offset + 2] = (value >>> 8) & 0xff;
+  buffer[offset + 3] = value & 0xff;
+};
+
+const createRom = () => {
+  const rom = new Uint8Array(0x1000);
+  writeLongBE(rom, 0x0000, 0x00010000); // initial SP
+  writeLongBE(rom, 0x0004, 0x00000400); // entry PC
+
+  // minimal program: moveq + stop
+  rom.set([0x70, 0x01, 0x4e, 0x72, 0x00, 0x00], 0x0400);
+  return rom;
+};
+
+describe('Tracer instruction register capability guard', () => {
+  it('fails fast before initializing Perfetto when register export is missing', async () => {
+    const system = await createSystem({
+      rom: createRom(),
+      ramSize: 0x2000,
+    });
+
+    const tracer: any = system.tracer;
+    if (!tracer.isAvailable()) {
+      system.cleanup();
+      return;
+    }
+
+    const musashi: any = tracer._musashi;
+    const wasmModule = musashi?._module ?? {};
+    const originalExport =
+      wasmModule._m68k_perfetto_enable_instruction_registers;
+
+    // Simulate a build missing the register export
+    wasmModule._m68k_perfetto_enable_instruction_registers = undefined;
+
+    const initSpy = jest.spyOn(musashi, 'perfettoInit');
+    const traceEnableSpy = jest.spyOn(musashi, 'traceEnable');
+
+    try {
+      expect(() =>
+        tracer.start({ instructions: true, instructionsRegisters: true })
+      ).toThrow(/instruction register tracing is not available/i);
+
+      expect(initSpy).not.toHaveBeenCalled();
+      expect(traceEnableSpy).not.toHaveBeenCalled();
+      expect((tracer as any)._active).toBe(false);
+      expect(musashi.perfettoIsInitialized()).toBe(false);
+    } finally {
+      wasmModule._m68k_perfetto_enable_instruction_registers = originalExport;
+      initSpy.mockRestore();
+      traceEnableSpy.mockRestore();
+      system.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fail fast if instructionsRegisters is requested but wasm lacks the export
- expose a helper on MusashiWrapper so the tracer can detect capability
- add Jest coverage for both wrapper behaviour and tracer guard path

## Testing
- timeout 60 npm test --workspace=@m68k/core
- npm run build --workspace=@m68k/core