### PR TITLE
Add SR register to instruction trace snapshots

### DIFF
--- a/m68k_perfetto.cc
+++ b/m68k_perfetto.cc
@@ -466,6 +466,8 @@ int M68kPerfettoTracer::handle_instruction_event(uint32_t pc, uint16_t opcode, u
             a_regs[i] = m68k_get_reg(nullptr, static_cast<m68k_register_t>(M68K_REG_A0 + i));
         }
 
+        const uint32_t sr = m68k_get_reg(nullptr, M68K_REG_SR);
+
         auto reg_annotation = instr_event.annotation("r");
         reg_annotation.pointer("d0", d_regs[0])
             .pointer("d1", d_regs[1])
@@ -482,7 +484,8 @@ int M68kPerfettoTracer::handle_instruction_event(uint32_t pc, uint16_t opcode, u
             .pointer("a4", a_regs[4])
             .pointer("a5", a_regs[5])
             .pointer("a6", a_regs[6])
-            .pointer("a7_sp", a_regs[7]);
+            .pointer("a7_sp", a_regs[7])
+            .integer("sr", static_cast<int64_t>(sr));
     }
 
     trace_builder_->end_slice(instr_thread_track_id_, end_ns);

--- a/tests/test_perfetto.cpp
+++ b/tests/test_perfetto.cpp
@@ -669,6 +669,7 @@ TEST_F(PerfettoTest, InstructionTracingCapturesRegistersWhenEnabled) {
     int register_annotations = 0;
     bool has_d0_entry = false;
     bool has_a7_entry = false;
+    bool has_sr_entry = false;
 
     for (const auto& packet : trace.packet()) {
         if (!packet.has_track_event()) {
@@ -694,6 +695,8 @@ TEST_F(PerfettoTest, InstructionTracingCapturesRegistersWhenEnabled) {
                     has_d0_entry = true;
                 } else if (entry.name() == "a7_sp" && entry.has_pointer_value()) {
                     has_a7_entry = true;
+                } else if (entry.name() == "sr" && entry.has_int_value()) {
+                    has_sr_entry = true;
                 }
             }
         }
@@ -705,6 +708,8 @@ TEST_F(PerfettoTest, InstructionTracingCapturesRegistersWhenEnabled) {
         << "Register annotation should provide D0 value";
     EXPECT_TRUE(has_a7_entry)
         << "Register annotation should provide A7/SP value";
+    EXPECT_TRUE(has_sr_entry)
+        << "Register annotation should provide SR value";
 #endif
 
     if (trace_data) {


### PR DESCRIPTION
## Summary
- extend Perfetto instruction register annotations to capture SR alongside D/A banks
- record SR as an integer value in the structured annotation
- tighten the GTest regression to assert SR presence

## Testing
- ENABLE_PERFETTO=1 ./build.sh
- npm run build
- timeout 60 npm test --workspace=@m68k/core