### PR TITLE
Clear stored fault records when resetting state

### DIFF
--- a/musashi_fault.c
+++ b/musashi_fault.c
@@ -1,10 +1,12 @@
 #include "musashi_fault.h"
 #include "m68kcpu.h"
 
+#include <string.h>
+
 static musashi_fault_record_t g_fault_record;
 
 void m68k_fault_clear(void) {
-  g_fault_record.active = 0;
+  memset(&g_fault_record, 0, sizeof(g_fault_record));
 }
 
 musashi_fault_record_t* m68k_fault_record_ptr(void) {


### PR DESCRIPTION
## Summary
- ensure musashi fault clearing wipes the entire record instead of only toggling the active flag
- include the required header for memset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c26b563f48331a7b26a4acfd8d34a)