### PR TITLE
Extract shared env parsing helper

### DIFF
--- a/packages/core/src/env-utils.ts
+++ b/packages/core/src/env-utils.ts
@@ -1,0 +1,9 @@
+export const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+export const parseBooleanEnv = (value: string | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  return TRUTHY_ENV_VALUES.has(value.trim().toLowerCase());
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ import type {
 import { M68kRegister } from '@m68k/common';
 import { MusashiWrapper, getModule } from './musashi-wrapper.js';
 import { mask24 } from './address-utils.js';
+import { parseBooleanEnv } from './env-utils.js';
 
 // Re-export types
 export type {
@@ -54,14 +55,6 @@ export type {
 
 const normalizeTraceAddress = mask24;
 const formatTraceHex = (value: number): string => `0x${(value >>> 0).toString(16)}`;
-
-const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
-
-const parseBooleanEnv = (value: string | undefined): boolean => {
-  if (!value) return false;
-  const normalized = value.trim().toLowerCase();
-  return TRUTHY_ENV_VALUES.has(normalized);
-};
 
 const env = typeof process !== 'undefined' ? process.env : undefined;
 

--- a/packages/core/src/musashi-wrapper.ts
+++ b/packages/core/src/musashi-wrapper.ts
@@ -6,6 +6,7 @@ type EmscriptenFunction = number;
 import { M68kRegister } from '@m68k/common';
 import type { MemoryLayout, MemoryTraceSource } from './types.js';
 import { mask24 } from './address-utils.js';
+import { parseBooleanEnv } from './env-utils.js';
 
 const NULL_EMSCRIPTEN_FUNCTION: EmscriptenFunction = 0;
 
@@ -54,16 +55,6 @@ const detectRuntime = (): RuntimeTag => {
   }
 
   return 'browser';
-};
-
-const TRUTHY_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
-
-const parseBooleanEnv = (value: string | undefined): boolean => {
-  if (!value) {
-    return false;
-  }
-
-  return TRUTHY_ENV_VALUES.has(value.trim().toLowerCase());
 };
 
 export interface MusashiEmscriptenModule {


### PR DESCRIPTION
## Summary
- add a shared `parseBooleanEnv` helper for boolean environment parsing
- reuse the helper in the core entrypoint and musashi wrapper to keep logic consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c26b563f48331a7b26a4acfd8d34a)