### PR TITLE
Rename static globals to avoid reserved identifiers

### DIFF
--- a/myfunc.cc
+++ b/myfunc.cc
@@ -20,13 +20,13 @@ typedef int (*pc_hook_t)(unsigned int pc);
 typedef int (*instr_hook_t)(unsigned int pc, unsigned int ir, unsigned int cycles);
 } // extern "C"
 
-static bool _initialized = false;
-static bool _enable_printf_logging = false;
-static read_mem_t _read_mem = nullptr;
-static write_mem_t _write_mem = nullptr;
-static pc_hook_t _pc_hook = nullptr;
-static instr_hook_t _instr_hook = nullptr;  // Full instruction hook (3 params)
-static std::unordered_set<unsigned int> _pc_hook_addrs;
+static bool g_initialized = false;
+static bool g_enable_printf_logging = false;
+static read_mem_t g_read_mem = nullptr;
+static write_mem_t g_write_mem = nullptr;
+static pc_hook_t g_pc_hook = nullptr;
+static instr_hook_t g_instr_hook = nullptr;  // Full instruction hook (3 params)
+static std::unordered_set<unsigned int> g_pc_hook_addrs;
 
 // Global constants used throughout
 static constexpr unsigned int kAddressSpaceMax = 0xFFFFFFFFu;
@@ -74,11 +74,11 @@ class SentinelSession {
       if (sp_now >= 4) {
         m68k_set_reg(M68K_REG_SP, sp_now - 4);
       }
-      if (_enable_printf_logging) {
+      if (g_enable_printf_logging) {
         printf("finalize_sentinel: consumed sp_now=0x%08X restored=0x%08X\n",
                sp_now, sp_now >= 4 ? sp_now - 4 : sp_now);
       }
-    } else if (_enable_printf_logging) {
+    } else if (g_enable_printf_logging) {
       printf("finalize_sentinel: not consumed, sp=0x%08X\n",
              m68k_get_reg(nullptr, M68K_REG_SP));
     }
@@ -107,30 +107,30 @@ class SentinelSession {
     saved_value = m68k_read_memory_32(saved_sp);
     m68k_write_memory_32(saved_sp, sentinel_pc);
     sentinel_installed = true;
-    if (_enable_printf_logging) {
+    if (g_enable_printf_logging) {
       printf("install_sentinel: sp=0x%08X saved=0x%08X sentinel=0x%08X\n",
              saved_sp, saved_value, sentinel_pc);
     }
   }
 };
-static SentinelSession _exec_session;
+static SentinelSession g_exec_session;
 
 // Helper to detect if current PC equals the active session's sentinel.
-// (removed free is_sentinel_pc; use _exec_session.isSentinelPc)
+// (removed free is_sentinel_pc; use g_exec_session.isSentinelPc)
 
 // RAII guard to manage ExecSession lifetime cleanly.
 class SessionGuard {
  public:
-  explicit SessionGuard(unsigned int entry_pc) { _exec_session.start(entry_pc); }
-  ~SessionGuard() { _exec_session.finish(); }
+  explicit SessionGuard(unsigned int entry_pc) { g_exec_session.start(entry_pc); }
+  ~SessionGuard() { g_exec_session.finish(); }
 };
 
 enum class HookResult : int { Continue = 0, Break = 1 };
 enum class BreakReason : int { None = 0, Trace = 1, InstrHook = 2, JsHook = 3, Sentinel = 4, Step = 5 };
-static BreakReason _last_break_reason = BreakReason::None;
+static BreakReason g_last_break_reason = BreakReason::None;
 
 static inline HookResult finalize_break_request(BreakReason reason, bool allow_break) {
-  _last_break_reason = reason;
+  g_last_break_reason = reason;
   if (allow_break) {
     m68k_end_timeslice();
     return HookResult::Break;
@@ -140,7 +140,7 @@ static inline HookResult finalize_break_request(BreakReason reason, bool allow_b
 
 // Single-step control state
 enum class StepState : int { Idle = 0, Arm = 1, BreakNext = 2 };
-static StepState _step_state = StepState::Idle;
+static StepState g_step_state = StepState::Idle;
 
 struct HookContext {
   unsigned int pc;
@@ -150,10 +150,10 @@ struct HookContext {
 
 static inline HookResult processHooks(const HookContext& ctx, bool allow_break) {
   // Step handling comes first: allow exactly one instruction, then break
-  if (_step_state == StepState::BreakNext) {
+  if (g_step_state == StepState::BreakNext) {
     // We are at the start of the next instruction; stop now
-    _step_state = StepState::Idle;
-    _last_break_reason = BreakReason::Step;
+    g_step_state = StepState::Idle;
+    g_last_break_reason = BreakReason::Step;
     // Important: do NOT call m68k_end_timeslice() here. That API rewrites
     // m68ki_initial_cycles to the current remaining cycle count and zeros
     // the remaining pool, which causes m68k_execute() to return the leftover
@@ -163,10 +163,10 @@ static inline HookResult processHooks(const HookContext& ctx, bool allow_break) 
     // request a break and let the execute loop exit naturally.
     return HookResult::Break;
   }
-  if (_step_state == StepState::Arm) {
+  if (g_step_state == StepState::Arm) {
     // Arm break for the next instruction and continue without allowing
     // any other hook to break this instruction.
-    _step_state = StepState::BreakNext;
+    g_step_state = StepState::BreakNext;
     return HookResult::Continue;
   }
 
@@ -177,8 +177,8 @@ static inline HookResult processHooks(const HookContext& ctx, bool allow_break) 
   }
 
   // Full instruction hook
-  if (_instr_hook) {
-    int result = _instr_hook(ctx.pc, ctx.ir, ctx.cycles);
+  if (g_instr_hook) {
+    int result = g_instr_hook(ctx.pc, ctx.ir, ctx.cycles);
     if (result != 0) {
       return finalize_break_request(BreakReason::InstrHook, allow_break);
     }
@@ -188,23 +188,23 @@ static inline HookResult processHooks(const HookContext& ctx, bool allow_break) 
   const int js_result = my_instruction_hook_function(ctx.pc);
   if (js_result != 0) {
     // JS requested a stop; vector to sentinel for deterministic exit
-    if (_exec_session.active) {
-      m68k_set_reg(M68K_REG_PC, _exec_session.sentinel_pc);
-      _exec_session.done = true;
-      if (_enable_printf_logging) {
+    if (g_exec_session.active) {
+      m68k_set_reg(M68K_REG_PC, g_exec_session.sentinel_pc);
+      g_exec_session.done = true;
+      if (g_enable_printf_logging) {
         printf("processHooks: JS break at pc=0x%08X -> sentinel=0x%08X\n",
-               ctx.pc, _exec_session.sentinel_pc);
+               ctx.pc, g_exec_session.sentinel_pc);
       }
     }
     return finalize_break_request(BreakReason::JsHook, allow_break);
   }
 
   // End if we hit the sentinel
-  if (_exec_session.isSentinelPc(ctx.pc)) {
-    _exec_session.done = true;
-    _exec_session.markConsumed();
-    _last_break_reason = BreakReason::Sentinel;
-    if (_enable_printf_logging) {
+  if (g_exec_session.isSentinelPc(ctx.pc)) {
+    g_exec_session.done = true;
+    g_exec_session.markConsumed();
+    g_last_break_reason = BreakReason::Sentinel;
+    if (g_enable_printf_logging) {
       printf("processHooks: sentinel pc encountered (pc=0x%08X)\n", ctx.pc);
     }
     if (allow_break) {
@@ -305,9 +305,9 @@ struct Region {
     return request_start >= region_start && request_end <= region_end;
   }
 };
-static std::vector<Region> _regions;
-static std::unordered_map<unsigned int, std::string> _function_names;
-static std::unordered_map<unsigned int, std::string> _memory_names;
+static std::vector<Region> g_regions;
+static std::unordered_map<unsigned int, std::string> g_function_names;
+static std::unordered_map<unsigned int, std::string> g_memory_names;
 
 struct MemoryRangeName {
   unsigned int start;
@@ -316,18 +316,18 @@ struct MemoryRangeName {
   std::string decorated_label;
 };
 
-static std::vector<MemoryRangeName> _memory_ranges;
-static std::unordered_map<unsigned int, std::string> _memory_range_cache;
+static std::vector<MemoryRangeName> g_memory_ranges;
+static std::unordered_map<unsigned int, std::string> g_memory_range_cache;
 
 static void invalidate_memory_range_cache(unsigned int start, unsigned int end) {
-  if (_memory_range_cache.empty() || start > end) {
+  if (g_memory_range_cache.empty() || start > end) {
     return;
   }
 
-  for (auto it = _memory_range_cache.begin(); it != _memory_range_cache.end();) {
+  for (auto it = g_memory_range_cache.begin(); it != g_memory_range_cache.end();) {
     const unsigned int addr = it->first;
     if (addr >= start && addr <= end) {
-      it = _memory_range_cache.erase(it);
+      it = g_memory_range_cache.erase(it);
     } else {
       ++it;
     }
@@ -336,49 +336,49 @@ static void invalidate_memory_range_cache(unsigned int start, unsigned int end) 
 
 extern "C" {
   int my_initialize() {
-    int result = _initialized;
-    _initialized = true;
+    int result = g_initialized;
+    g_initialized = true;
     return result;
   }
   void enable_printf_logging() {
     printf("enable_printf_logging\n");
-    _enable_printf_logging = true;
+    g_enable_printf_logging = true;
   }
   void set_read_mem_func(read_mem_t func) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("set_read_mem_func: %p\n", (void*)func);
-     _read_mem = func;
+     g_read_mem = func;
   }
   void set_write_mem_func(write_mem_t func) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("set_write_mem_func: %p\n", (void*)func);
-    _write_mem = func;
+    g_write_mem = func;
   }
   void set_pc_hook_func(pc_hook_t func) {
-    _pc_hook = func;
+    g_pc_hook = func;
   }
   
   // Full instruction hook setter (3 params: pc, ir, cycles)
   void set_full_instr_hook_func(instr_hook_t func) {
-    _instr_hook = func;
+    g_instr_hook = func;
   }
   
   // JavaScript callback setters - these are what TypeScript actually calls
   void set_read8_callback(int32_t fp) {
     js_read8_callback = (read8_callback_t)fp;
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("set_read8_callback: %p\n", (void*)fp);
   }
   
   void set_write8_callback(int32_t fp) {
     js_write8_callback = (write8_callback_t)fp;
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("set_write8_callback: %p\n", (void*)fp);
   }
   
   void set_probe_callback(int32_t fp) {
     js_probe_callback = (probe_callback_t)fp;
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("set_probe_callback: %p\n", (void*)fp);
   }
   // Normalize to 24-bit, even address (68k opcodes are word-aligned)
@@ -387,37 +387,37 @@ extern "C" {
   }
   
   void add_pc_hook_addr(unsigned int addr) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("add_pc_hook_addr: %p (normalized: %p)\n", (void*)addr, (void*)norm_pc(addr));
-    _pc_hook_addrs.insert(norm_pc(addr));
+    g_pc_hook_addrs.insert(norm_pc(addr));
   }
   void add_region(unsigned int start, unsigned int size, void* data) {
-    if (_enable_printf_logging) {
+    if (g_enable_printf_logging) {
       printf("DEBUG: add_region called: start=0x%x size=0x%x data=%p (regions before: %zu)\n", 
-             start, size, data, _regions.size());
+             start, size, data, g_regions.size());
     }
-    _regions.emplace_back(start, size, data);
+    g_regions.emplace_back(start, size, data);
     
     // Debug: verify the region was added properly
-    if (_enable_printf_logging) {
-      const auto& r = _regions.back();
+    if (g_enable_printf_logging) {
+      const auto& r = g_regions.back();
       printf("DEBUG: Region added successfully: start_=0x%x size_=0x%x data_=%p (total regions: %zu)\n", 
-             r.start_, r.size_, (void*)r.data_, _regions.size());
+             r.start_, r.size_, (void*)r.data_, g_regions.size());
     }
   }
   void clear_regions() {
-    _regions.clear();
+    g_regions.clear();
   }
   void clear_pc_hook_addrs() {
-    _pc_hook_addrs.clear();
+    g_pc_hook_addrs.clear();
   }
   
   void clear_pc_hook_func() {
-    _pc_hook = nullptr;
+    g_pc_hook = nullptr;
   }
 
   void clear_instr_hook_func() {
-    _instr_hook = nullptr;
+    g_instr_hook = nullptr;
   }
 
   // Provide a clean entry helper that sets sane CPU state and jumps to pc
@@ -435,19 +435,19 @@ extern "C" {
   }
   
   void reset_myfunc_state() {
-    _initialized = false;
-    _enable_printf_logging = false;
-    _read_mem = nullptr;
-    _write_mem = nullptr;
-    _pc_hook = nullptr;
-    _instr_hook = nullptr;
-    _pc_hook_addrs.clear();
-    _regions.clear();
-    _function_names.clear();
-    _memory_names.clear();
-    _memory_ranges.clear();
-    _memory_range_cache.clear();
-    _exec_session = SentinelSession{};
+    g_initialized = false;
+    g_enable_printf_logging = false;
+    g_read_mem = nullptr;
+    g_write_mem = nullptr;
+    g_pc_hook = nullptr;
+    g_instr_hook = nullptr;
+    g_pc_hook_addrs.clear();
+    g_regions.clear();
+    g_function_names.clear();
+    g_memory_names.clear();
+    g_memory_ranges.clear();
+    g_memory_range_cache.clear();
+    g_exec_session = SentinelSession{};
     m68k_fault_clear();
   }
   
@@ -457,16 +457,16 @@ extern "C" {
   
   void register_function_name(unsigned int address, const char* name) {
     if (name) {
-      _function_names[address] = name;
-      if (_enable_printf_logging)
+      g_function_names[address] = name;
+      if (g_enable_printf_logging)
         printf("register_function_name: 0x%08X = '%s'\n", address, name);
     }
   }
   
   void register_memory_name(unsigned int address, const char* name) {
     if (name) {
-      _memory_names[address] = name;
-      if (_enable_printf_logging)
+      g_memory_names[address] = name;
+      if (g_enable_printf_logging)
         printf("register_memory_name: 0x%08X = '%s'\n", address, name);
     }
   }
@@ -491,7 +491,7 @@ extern "C" {
     };
 
     bool replaced = false;
-    for (auto& existing : _memory_ranges) {
+    for (auto& existing : g_memory_ranges) {
       if (existing.start == range.start) {
         invalidate_memory_range_cache(existing.start, existing.end);
         existing = range;
@@ -500,14 +500,14 @@ extern "C" {
       }
     }
     if (!replaced) {
-      _memory_ranges.push_back(range);
+      g_memory_ranges.push_back(range);
     }
 
     invalidate_memory_range_cache(range.start, range.end);
 
-    _memory_names[range.start] = range.decorated_label;
+    g_memory_names[range.start] = range.decorated_label;
 
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf(
         "register_memory_range: 0x%08X-0x%08X = '%s'\n",
         range.start,
@@ -516,38 +516,38 @@ extern "C" {
   }
 
   void clear_registered_names() {
-    _function_names.clear();
-    _memory_names.clear();
-    _memory_ranges.clear();
-    _memory_range_cache.clear();
-    if (_enable_printf_logging)
+    g_function_names.clear();
+    g_memory_names.clear();
+    g_memory_ranges.clear();
+    g_memory_range_cache.clear();
+    if (g_enable_printf_logging)
       printf("clear_registered_names: cleared all names\n");
   }
   
   const char* get_function_name(unsigned int address) {
-    auto it = _function_names.find(address);
-    return (it != _function_names.end()) ? it->second.c_str() : nullptr;
+    auto it = g_function_names.find(address);
+    return (it != g_function_names.end()) ? it->second.c_str() : nullptr;
   }
   
   const char* get_memory_name(unsigned int address) {
-    auto direct = _memory_names.find(address);
-    if (direct != _memory_names.end()) {
+    auto direct = g_memory_names.find(address);
+    if (direct != g_memory_names.end()) {
       return direct->second.c_str();
     }
 
-    auto cached = _memory_range_cache.find(address);
-    if (cached != _memory_range_cache.end()) {
+    auto cached = g_memory_range_cache.find(address);
+    if (cached != g_memory_range_cache.end()) {
       return cached->second.c_str();
     }
 
-    for (const auto& range : _memory_ranges) {
+    for (const auto& range : g_memory_ranges) {
       if (address < range.start || address > range.end) {
         continue;
       }
 
       if (address == range.start) {
-        auto base = _memory_names.find(range.start);
-        if (base != _memory_names.end()) {
+        auto base = g_memory_names.find(range.start);
+        if (base != g_memory_names.end()) {
           return base->second.c_str();
         }
         return range.decorated_label.c_str();
@@ -556,7 +556,7 @@ extern "C" {
       const unsigned int offset = address - range.start;
       std::ostringstream label;
       label << range.base_name << "+0x" << std::uppercase << std::hex << offset;
-      auto& stored = _memory_range_cache[address];
+      auto& stored = g_memory_range_cache[address];
       stored = label.str();
       return stored.c_str();
     }
@@ -566,10 +566,10 @@ extern "C" {
 
   // Break reason helpers (for tests / debugging)
   int m68k_get_last_break_reason() {
-    return static_cast<int>(_last_break_reason);
+    return static_cast<int>(g_last_break_reason);
   }
   void m68k_reset_last_break_reason() {
-    _last_break_reason = BreakReason::None;
+    g_last_break_reason = BreakReason::None;
   }
 
   // Run until JS-side PC hook requests a stop; when that happens,
@@ -578,29 +578,29 @@ extern "C" {
   unsigned long long m68k_call_until_js_stop(unsigned int entry_pc, unsigned int timeslice) {
     if (timeslice == 0) timeslice = kDefaultTimeslice;
     SessionGuard guard(entry_pc);
-    if (_enable_printf_logging) {
+    if (g_enable_printf_logging) {
       const unsigned int sp_start = m68k_get_reg(nullptr, M68K_REG_SP);
       printf("call_until_js_stop: start pc=0x%08X sp=0x%08X timeslice=%u\n",
              entry_pc, sp_start, timeslice);
     }
     unsigned long long total_cycles = 0;
     unsigned int iter = 0;
-    while (!_exec_session.done) {
+    while (!g_exec_session.done) {
       total_cycles += m68k_execute(timeslice);
-      if (_enable_printf_logging && iter < 16) {
+      if (g_enable_printf_logging && iter < 16) {
         const unsigned int loop_pc = m68k_get_reg(nullptr, M68K_REG_PC);
         const unsigned int loop_sp = m68k_get_reg(nullptr, M68K_REG_SP);
         printf("call_until_js_stop: iter=%u pc=0x%08X sp=0x%08X done=%d\n",
-               iter, loop_pc, loop_sp, _exec_session.done ? 1 : 0);
+               iter, loop_pc, loop_sp, g_exec_session.done ? 1 : 0);
       }
       ++iter;
     }
-    _exec_session.finalize();
-    if (_enable_printf_logging) {
+    g_exec_session.finalize();
+    if (g_enable_printf_logging) {
       const unsigned int sp_end = m68k_get_reg(nullptr, M68K_REG_SP);
       const unsigned int pc_end = m68k_get_reg(nullptr, M68K_REG_PC);
       printf("call_until_js_stop: exit pc=0x%08X sp=0x%08X cycles=%llu reason=%d\n",
-             pc_end, sp_end, total_cycles, static_cast<int>(_last_break_reason));
+             pc_end, sp_end, total_cycles, static_cast<int>(g_last_break_reason));
     }
     return total_cycles;
   }
@@ -609,11 +609,11 @@ extern "C" {
   unsigned long long m68k_step_one(void) {
     // Capture start PC for accurate boundary normalization
     const unsigned int start_pc = m68k_get_reg(nullptr, M68K_REG_PC);
-    _step_state = StepState::Arm;
+    g_step_state = StepState::Arm;
     unsigned long long cycles = m68k_execute(kDefaultTimeslice);
     // If CPU became stopped before next hook (e.g., STOP), ensure clean state
-    if (_step_state != StepState::Idle) {
-      _step_state = StepState::Idle;
+    if (g_step_state != StepState::Idle) {
+      g_step_state = StepState::Idle;
     }
 
     // Determine normalized end-of-instruction PC.
@@ -691,10 +691,10 @@ extern "C" {
 
 extern "C" unsigned int my_read_memory(unsigned int address, int size) {
   // Check regions first
-  for (auto& region : _regions) {
+  for (auto& region : g_regions) {
     const auto val = region.read(address, size);
     if (val) {
-      if (_enable_printf_logging && address < 0x100) {
+      if (g_enable_printf_logging && address < 0x100) {
         printf("DEBUG: my_read_memory region hit: addr=0x%x size=%d value=0x%x (region start=0x%x)\n", 
                address, size, *val, region.start_);
       }
@@ -711,7 +711,7 @@ extern "C" unsigned int my_read_memory(unsigned int address, int size) {
       case 4: result = read32_be(address); break;
       default: result = 0; break;
     }
-    if (_enable_printf_logging && address < 0x100) {
+    if (g_enable_printf_logging && address < 0x100) {
       printf("DEBUG: my_read_memory JS callback: addr=0x%x size=%d value=0x%x\n", 
              address, size, result);
     }
@@ -719,18 +719,18 @@ extern "C" unsigned int my_read_memory(unsigned int address, int size) {
   }
   
   // Fall back to old callback system
-  if (_read_mem) {
-    unsigned int result = _read_mem(address, size);
-    if (_enable_printf_logging && address < 0x100) {
+  if (g_read_mem) {
+    unsigned int result = g_read_mem(address, size);
+    if (g_enable_printf_logging && address < 0x100) {
       printf("DEBUG: my_read_memory old callback: addr=0x%x size=%d value=0x%x callback=%p\n", 
-             address, size, result, (void*)_read_mem);
+             address, size, result, (void*)g_read_mem);
     }
     return result;
   }
   
-  if (_enable_printf_logging && address < 0x100) {
+  if (g_enable_printf_logging && address < 0x100) {
     printf("DEBUG: my_read_memory NO HANDLER: addr=0x%x size=%d, %zu regions, callback=%p\n", 
-           address, size, _regions.size(), (void*)_read_mem);
+           address, size, g_regions.size(), (void*)g_read_mem);
   }
   return 0; // Return 0 if no handler is set
 }
@@ -739,7 +739,7 @@ extern "C" unsigned int my_read_memory(unsigned int address, int size) {
 
 extern "C" void my_write_memory(unsigned int address, int size, unsigned int value) {
   // Check regions first
-  for (auto& region : _regions) {
+  for (auto& region : g_regions) {
     if (region.write(address, size, value)) {
       return; // Write handled by region
     }
@@ -756,8 +756,8 @@ extern "C" void my_write_memory(unsigned int address, int size, unsigned int val
   }
   
   // Fall back to old callback system
-  if (_write_mem) {
-    _write_mem(address, size, value);
+  if (g_write_mem) {
+    g_write_mem(address, size, value);
   }
 }
 
@@ -772,18 +772,18 @@ extern "C" void my_write_memory_glue(uint32_t address, uint32_t value, int size)
 
 // Helper: whether to invoke legacy PC hook for given pc based on filter set
 static inline bool should_invoke_pc_hook(unsigned int pc) {
-  if (_pc_hook_addrs.empty()) return true; // backward compatible: hook all
-  return _pc_hook_addrs.find(pc) != _pc_hook_addrs.end();
+  if (g_pc_hook_addrs.empty()) return true; // backward compatible: hook all
+  return g_pc_hook_addrs.find(pc) != g_pc_hook_addrs.end();
 }
 
 int my_instruction_hook_function(unsigned int pc_raw) {
   const uint32_t pc = norm_pc(pc_raw);
   
-  if (_enable_printf_logging) {
+  if (g_enable_printf_logging) {
     static int hook_count = 0;
     if (hook_count < 5) {
-      printf("DEBUG: my_instruction_hook_function called with pc=0x%x, _pc_hook=%p, js_probe_callback=%p\n", 
-             pc, (void*)_pc_hook, (void*)js_probe_callback);
+      printf("DEBUG: my_instruction_hook_function called with pc=0x%x, g_pc_hook=%p, js_probe_callback=%p\n", 
+             pc, (void*)g_pc_hook, (void*)js_probe_callback);
       hook_count++;
     }
   }
@@ -797,8 +797,8 @@ int my_instruction_hook_function(unsigned int pc_raw) {
   }
 
   // Call legacy PC hook if present and allowed by filter
-  if (_pc_hook && should_invoke_pc_hook(pc)) {
-    return _pc_hook(pc);
+  if (g_pc_hook && should_invoke_pc_hook(pc)) {
+    return g_pc_hook(pc);
   }
 
   return 0;
@@ -812,7 +812,7 @@ int my_instruction_hook_function(unsigned int pc_raw) {
 __attribute__((noinline, used))
 #endif
 extern "C" int m68k_instruction_hook_wrapper(unsigned int pc, unsigned int ir, unsigned int cycles) {
-    if (_enable_printf_logging) {
+    if (g_enable_printf_logging) {
         static int wrapper_count = 0;
         if (wrapper_count < 5) {
             printf("DEBUG: m68k_instruction_hook_wrapper called with pc=0x%x, ir=0x%x, cycles=%d\n", pc, ir, cycles);
@@ -836,58 +836,58 @@ extern "C" int m68k_instruction_hook_wrapper(unsigned int pc, unsigned int ir, u
 extern "C" {
   /* Perfetto lifecycle management */
   int perfetto_init(const char* process_name) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_init: %s\n", process_name ? process_name : "NULL");
     return m68k_perfetto_init(process_name);
   }
   
   void perfetto_destroy() {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_destroy\n");
     m68k_perfetto_destroy();
   }
   
   /* Feature enable/disable */
   void perfetto_enable_flow(int enable) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_enable_flow: %d\n", enable);
     m68k_perfetto_enable_flow(enable);
   }
   
   void perfetto_enable_memory(int enable) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_enable_memory: %d\n", enable);
     m68k_perfetto_enable_memory(enable);
   }
   
   void perfetto_enable_instructions(int enable) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_enable_instructions: %d\n", enable);
     m68k_perfetto_enable_instructions(enable);
   }
 
   void perfetto_enable_instruction_registers(int enable) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_enable_instruction_registers: %d\n", enable);
     m68k_perfetto_enable_instruction_registers(enable);
   }
   
   /* Export trace data (critical for WASM) */
   int perfetto_export_trace(uint8_t** data_out, size_t* size_out) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_export_trace: %p %p\n", (void*)data_out, (void*)size_out);
     return m68k_perfetto_export_trace(data_out, size_out);
   }
   
   void perfetto_free_trace_data(uint8_t* data) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_free_trace_data: %p\n", (void*)data);
     m68k_perfetto_free_trace_data(data);
   }
   
   /* Native-only file save */
   int perfetto_save_trace(const char* filename) {
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_save_trace: %s\n", filename ? filename : "NULL");
     return m68k_perfetto_save_trace(filename);
   }
@@ -895,7 +895,7 @@ extern "C" {
   /* Status */
   int perfetto_is_initialized() {
     int result = m68k_perfetto_is_initialized();
-    if (_enable_printf_logging)
+    if (g_enable_printf_logging)
       printf("perfetto_is_initialized: %d\n", result);
     return result;
   }


### PR DESCRIPTION
## Summary
- rename global static variables in `myfunc.cc` to avoid reserved leading-underscore identifiers
- update usages across the file while keeping behavior unchanged

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693161a8e4e08331b7f610db5f2eaa41)